### PR TITLE
Minor fix in VCS good channel selection

### DIFF
--- a/turbustat/statistics/vca_vcs/vca_vcs.py
+++ b/turbustat/statistics/vca_vcs/vca_vcs.py
@@ -39,7 +39,7 @@ class VCA(object):
         if np.isnan(self.cube).any():
             self.cube[np.isnan(self.cube)] = 0
             # Feel like this should be more specific
-            self.good_channel_count = np.sum(self.cube[0, :, :] != 0)
+            self.good_channel_count = np.sum(self.cube.max(axis=0) != 0)
         self.header = header
         self.shape = self.cube.shape
 


### PR DESCRIPTION
if the first channel is all zeros (e.g., padded to allow for different # of slice sizes in VCA), need a different way to define good "channels" (is the definition of channels right anyway?  seems like this is good spatial pixels...)
