### PR TITLE
Using numpy rfft to save memory

### DIFF
--- a/Examples/interruptible_pool.py
+++ b/Examples/interruptible_pool.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2010-2013 Daniel Foreman-Mackey & contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Python's multiprocessing.Pool class doesn't interact well with
+``KeyboardInterrupt`` signals, as documented in places such as:
+
+* `<http://stackoverflow.com/questions/1408356/>`_
+* `<http://stackoverflow.com/questions/11312525/>`_
+* `<http://noswap.com/blog/python-multiprocessing-keyboardinterrupt>`_
+
+Various workarounds have been shared. Here, we adapt the one proposed in the
+last link above, by John Reese, and shared as
+
+* `<https://github.com/jreese/multiprocessing-keyboardinterrupt/>`_
+
+Our version is a drop-in replacement for multiprocessing.Pool ... as long as
+the map() method is the only one that needs to be interrupt-friendly.
+
+Contributed by Peter K. G. Williams <peter@newton.cx>.
+
+*Added in version 2.1.0*
+
+"""
+
+from __future__ import (division, print_function, absolute_import,
+                        unicode_literals)
+
+__all__ = ["InterruptiblePool"]
+
+import signal
+import functools
+from multiprocessing.pool import Pool
+from multiprocessing import TimeoutError
+
+
+def _initializer_wrapper(actual_initializer, *rest):
+    """
+    We ignore SIGINT. It's up to our parent to kill us in the typical
+    condition of this arising from ``^C`` on a terminal. If someone is
+    manually killing us with that signal, well... nothing will happen.
+
+    """
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    if actual_initializer is not None:
+        actual_initializer(*rest)
+
+
+class InterruptiblePool(Pool):
+    """
+    A modified version of :class:`multiprocessing.pool.Pool` that has better
+    behavior with regard to ``KeyboardInterrupts`` in the :func:`map` method.
+
+    :param processes: (optional)
+        The number of worker processes to use; defaults to the number of CPUs.
+
+    :param initializer: (optional)
+        Either ``None``, or a callable that will be invoked by each worker
+        process when it starts.
+
+    :param initargs: (optional)
+        Arguments for *initializer*; it will be called as
+        ``initializer(*initargs)``.
+
+    :param kwargs: (optional)
+        Extra arguments. Python 2.7 supports a ``maxtasksperchild`` parameter.
+
+    """
+    wait_timeout = 3600
+
+    def __init__(self, processes=None, initializer=None, initargs=(),
+                 **kwargs):
+        new_initializer = functools.partial(_initializer_wrapper, initializer)
+        super(InterruptiblePool, self).__init__(processes, new_initializer,
+                                                initargs, **kwargs)
+
+    def map(self, func, iterable, chunksize=None):
+        """
+        Equivalent of ``map()`` built-in, without swallowing
+        ``KeyboardInterrupt``.
+
+        :param func:
+            The function to apply to the items.
+
+        :param iterable:
+            An iterable of items that will have `func` applied to them.
+
+        """
+        # The key magic is that we must call r.get() with a timeout, because
+        # a Condition.wait() without a timeout swallows KeyboardInterrupts.
+        r = self.map_async(func, iterable, chunksize)
+
+        while True:
+            try:
+                return r.get(self.wait_timeout)
+            except TimeoutError:
+                pass
+            except KeyboardInterrupt:
+                self.terminate()
+                self.join()
+                raise
+            # Other exceptions propagate up.

--- a/Examples/pairwise_comparison.py
+++ b/Examples/pairwise_comparison.py
@@ -1,0 +1,98 @@
+
+'''
+Compute pairwise comparisons between the timesteps of a sim.
+'''
+
+from turbustat.statistics import stats_wrapper
+from turbustat.data_reduction import Mask_and_Moments
+
+from astropy.io.fits import getdata
+from astropy.wcs import WCS
+from spectral_cube import SpectralCube, LazyMask
+import numpy as np
+from interruptible_pool import InterruptiblePool as Pool
+from itertools import izip, combinations, repeat
+from pandas import DataFrame
+
+
+def pairwise(files, statistics=None, ncores=1, save=False,
+             save_name='pairwise'):
+    '''
+    Create a distance matrix for a set of simulations.
+    '''
+
+    num = len(files)
+
+    pos = np.arange(num)
+
+    pool = Pool(processes=ncores)
+
+    output = pool.map(single_input,
+                      izip(repeat(files),
+                           combinations(pos, 2),
+                           repeat(statistics)))
+
+    pool.close()
+
+    dist_matrices = np.zeros((len(output[0][0]), num, num))
+
+    for out in output:
+        for i, stat in enumerate(out[0].keys()):
+            dist_matrices[i, out[1], out[2]] = out[0][stat]
+
+    if save:
+        stats = out[0].keys()
+
+        for i, stat in enumerate(stats):
+            df = DataFrame(dist_matrices[i, :, :])
+            df.to_csv(save_name+'_'+stat+'_distmat.csv')
+    else:
+        return dist_matrices
+
+
+def timestep_wrapper(files, pos, statistics):
+
+    pos1, pos2 = pos
+    # Derive the property arrays assuming uniform noise (for sims)
+    dataset1 = load_and_reduce(files[pos1])
+    dataset2 = load_and_reduce(files[pos2])
+
+    distances = stats_wrapper(dataset1, dataset2,
+                              statistics=statistics, multicore=True)
+    return distances, pos1, pos2
+
+
+def single_input(a):
+    return timestep_wrapper(*a)
+
+
+def load_and_reduce(filename, add_noise=False, rms_noise=0.001,
+                    nsig=3):
+    '''
+    Load the cube in and derive the property arrays.
+    '''
+
+    if add_noise:
+        if rms_noise is None:
+            raise TypeError("Must specify value of rms noise.")
+
+        cube, hdr = getdata(filename, header=True)
+
+        from scipy.stats import norm
+        cube += norm.rvs(0.0, rms_noise, cube.shape)
+
+        sc = SpectralCube(data=cube, wcs=WCS(hdr))
+
+    else:
+        sc = SpectralCube.read(filename)
+
+    mask = LazyMask(np.isfinite, sc)
+    sc = sc.with_mask(mask)
+
+    reduc = Mask_and_Moments(sc)
+    three_sig_mask = reduc.cube > nsig * reduc.scale
+    reduc.make_mask(mask=three_sig_mask)
+    reduc.make_moments()
+    reduc.make_moment_errors()
+
+    return reduc.to_dict()

--- a/turbustat/statistics/mvc/mvc.py
+++ b/turbustat/statistics/mvc/mvc.py
@@ -4,11 +4,7 @@
 import numpy as np
 import statsmodels.formula.api as sm
 from pandas import Series, DataFrame
-
-try:
-    from scipy.fftpack import fft2, fftshift
-except ImportError:
-    from numpy.fft import fft2, fftshift
+from numpy.fft import fft2, fftshift
 
 from ..psds import pspec
 

--- a/turbustat/statistics/mvc/mvc.py
+++ b/turbustat/statistics/mvc/mvc.py
@@ -66,11 +66,11 @@ class MVC(object):
         subtracted by the square of the normalized centroid.
         '''
 
-        term1 = fft2(self.centroid.astype("f8")*self.moment0.astype("f8"))
+        term1 = fft2(self.centroid*self.moment0)
 
         term2 = np.power(self.linewidth, 2) + np.power(self.centroid, 2)
 
-        mvc_fft = term1 - term2 * fft2(self.moment0.astype("f8"))
+        mvc_fft = term1 - term2 * fft2(self.moment0)
 
         # Shift to the center
         mvc_fft = fftshift(mvc_fft)

--- a/turbustat/statistics/mvc/mvc.py
+++ b/turbustat/statistics/mvc/mvc.py
@@ -33,7 +33,6 @@ class MVC(object):
     """
 
     def __init__(self, centroid, moment0, linewidth, header):
-        # super(MVC, self).__init__()
         self.centroid = centroid
         self.moment0 = moment0
         self.linewidth = linewidth

--- a/turbustat/statistics/pspec_bispec/pspec_bispec.py
+++ b/turbustat/statistics/pspec_bispec/pspec_bispec.py
@@ -6,11 +6,7 @@ import numpy.random as ra
 from ..psds import pspec
 import statsmodels.formula.api as sm
 from pandas import Series, DataFrame
-
-try:
-    from scipy.fftpack import fft2, fftshift
-except ImportError:
-    from numpy.fft import fft2, fftshift
+from numpy.fft import fft2, fftshift
 
 
 class PowerSpectrum(object):

--- a/turbustat/statistics/pspec_bispec/pspec_bispec.py
+++ b/turbustat/statistics/pspec_bispec/pspec_bispec.py
@@ -4,6 +4,7 @@
 import numpy as np
 import numpy.random as ra
 from ..psds import pspec
+from ..rfft_to_fft import rfft_to_fft
 import statsmodels.formula.api as sm
 from pandas import Series, DataFrame
 from numpy.fft import fft2, fftshift
@@ -51,9 +52,9 @@ class PowerSpectrum(object):
         Compute the 2D power spectrum.
         '''
 
-        fft = fftshift(fft2(self.weighted_img.astype("f8")))
+        fft = fftshift(rfft_to_fft(self.weighted_img))
 
-        self.ps2D = np.abs(fft) ** 2.
+        self.ps2D = np.power(fft, 2.)
 
         return self
 
@@ -267,7 +268,7 @@ class BiSpectrum(object):
             Sets the seed for the distribution draws.
         '''
 
-        fft = np.fft.fft2(self.img.astype("f8"))
+        fft = np.fft.fft2(self.img)
         conjfft = np.conj(fft)
         ra.seed(seed)
 

--- a/turbustat/statistics/rfft_to_fft.py
+++ b/turbustat/statistics/rfft_to_fft.py
@@ -1,14 +1,28 @@
+# Licensed under an MIT open source license - see LICENSE
 
 import numpy as np
 
 '''
 Reconstruct FFT output from RFFT in order to save memory
+Largely follows the solution from:
+http://stackoverflow.com/questions/25147045/full-frequency-array-reconstruction-after-numpy-fft-rfftn
 '''
 
 
 def rfft_to_fft(image):
     '''
+    Perform a RFFT on the image (2 or 3D) and return the absolute value in
+    the same format as you would get with the fft (negative frequencies).
+    This avoids ever having to have the full complex cube in memory.
 
+    Inputs
+    ------
+    image : numpy.ndarray
+        2 or 3D array.
+
+    Outputs
+    -------
+    fft_abs : absolute value of the fft.
     '''
 
     ndim = len(image.shape)

--- a/turbustat/statistics/rfft_to_fft.py
+++ b/turbustat/statistics/rfft_to_fft.py
@@ -1,0 +1,48 @@
+
+import numpy as np
+
+'''
+Reconstruct FFT output from RFFT in order to save memory
+'''
+
+
+def rfft_to_fft(image):
+    '''
+
+    '''
+
+    ndim = len(image.shape)
+
+    if ndim < 2 or ndim > 3:
+        raise TypeError("Dimension of image must be 2D or 3D.")
+
+    last_dim = image.shape[-1]
+
+    fft_abs = np.abs(np.fft.rfftn(image))
+
+
+    if ndim == 2:
+        if last_dim % 2 == 0:
+            fftstar_abs = fft_abs[:, -2:0:-1]
+        else:
+            fftstar_abs = fft_abs[:, -1:0:-1]
+
+        fftstar_abs[1::, :] = fftstar_abs[:0:-1, :]
+
+        fft_abs = np.roll(fft_abs[::-1, :], 1, axis=0)
+
+        return np.concatenate((fft_abs, fftstar_abs), axis=1)
+
+    elif ndim == 3:
+        if last_dim % 2 == 0:
+            fftstar_abs = fft_abs[:, :, -2:0:-1]
+        else:
+            fftstar_abs = fft_abs[:, :, -1:0:-1]
+
+        fftstar_abs[1::, :, :] = fftstar_abs[:0:-1, :, :]
+        fftstar_abs[:, 1::, :] = fftstar_abs[:, :0:-1, :]
+
+        fft_abs = np.roll(fft_abs[::-1, :, :], 1, axis=0)
+        fft_abs = np.roll(fft_abs[:, ::-1, :], 1, axis=1)
+
+        return np.concatenate((fft_abs, fftstar_abs), axis=2)

--- a/turbustat/statistics/rfft_to_fft.py
+++ b/turbustat/statistics/rfft_to_fft.py
@@ -20,29 +20,23 @@ def rfft_to_fft(image):
 
     fft_abs = np.abs(np.fft.rfftn(image))
 
-
     if ndim == 2:
         if last_dim % 2 == 0:
-            fftstar_abs = fft_abs[:, -2:0:-1]
+            fftstar_abs = fft_abs.copy()[:, -2:0:-1]
         else:
-            fftstar_abs = fft_abs[:, -1:0:-1]
+            fftstar_abs = fft_abs.copy()[:, -1:0:-1]
 
         fftstar_abs[1::, :] = fftstar_abs[:0:-1, :]
-
-        fft_abs = np.roll(fft_abs[::-1, :], 1, axis=0)
 
         return np.concatenate((fft_abs, fftstar_abs), axis=1)
 
     elif ndim == 3:
         if last_dim % 2 == 0:
-            fftstar_abs = fft_abs[:, :, -2:0:-1]
+            fftstar_abs = fft_abs.copy()[:, :, -2:0:-1]
         else:
-            fftstar_abs = fft_abs[:, :, -1:0:-1]
+            fftstar_abs = fft_abs.copy()[:, :, -1:0:-1]
 
         fftstar_abs[1::, :, :] = fftstar_abs[:0:-1, :, :]
         fftstar_abs[:, 1::, :] = fftstar_abs[:, :0:-1, :]
-
-        fft_abs = np.roll(fft_abs[::-1, :, :], 1, axis=0)
-        fft_abs = np.roll(fft_abs[:, ::-1, :], 1, axis=1)
 
         return np.concatenate((fft_abs, fftstar_abs), axis=2)

--- a/turbustat/statistics/vca_vcs/vca_vcs.py
+++ b/turbustat/statistics/vca_vcs/vca_vcs.py
@@ -4,11 +4,7 @@
 import numpy as np
 import statsmodels.api as sm
 import warnings
-
-try:
-    from scipy.fftpack import fftn, fftfreq, fftshift
-except ImportError:
-    from numpy.fft import fftn, fftfreq, fftshift
+from numpy.fft import fftn, fftfreq, fftshift
 
 from ..lm_seg import Lm_Seg
 from ..psds import pspec

--- a/turbustat/statistics/vca_vcs/vca_vcs.py
+++ b/turbustat/statistics/vca_vcs/vca_vcs.py
@@ -4,10 +4,11 @@
 import numpy as np
 import statsmodels.api as sm
 import warnings
-from numpy.fft import fftn, fftfreq, fftshift
+from numpy.fft import fftfreq, fftshift
 
 from ..lm_seg import Lm_Seg
 from ..psds import pspec
+from ..rfft_to_fft import rfft_to_fft
 from slice_thickness import change_slice_thickness
 
 
@@ -56,9 +57,9 @@ class VCA(object):
         Compute the 2D power spectrum.
         '''
 
-        vca_fft = fftshift(fftn(self.cube.astype("f8")))
+        vca_fft = fftshift(rfft_to_fft(self.cube))
 
-        self.ps2D = (np.abs(vca_fft) ** 2.).sum(axis=0)
+        self.ps2D = np.power(vca_fft, 2.).sum(axis=0)
 
         return self
 
@@ -269,8 +270,8 @@ class VCS(object):
         Take the FFT of each spectrum in velocity dimension.
         '''
 
-        self.fftcube = fftn(self.cube.astype("f8"))
-        self.correlated_cube = np.abs(self.fftcube) ** 2.
+        self.fftcube = rfft_to_fft(self.cube)
+        self.correlated_cube = np.power(self.fftcube, 2.)
 
         return self
 

--- a/turbustat/statistics/wavelets/wavelet_transform.py
+++ b/turbustat/statistics/wavelets/wavelet_transform.py
@@ -131,7 +131,7 @@ class wt2D(object):
         self.Wf = np.zeros((A, N, M), 'complex')
         for i, an in enumerate(self.scales):
             psi_ft_bar = an * self.wavelet.psi_ft(an * k, an * l)
-            self.Wf[i, :, :] = ifftn(f_ft * psi_ft_bar, shape=(N, M))
+            self.Wf[i, :, :] = ifftn(f_ft * psi_ft_bar)
 
         self.Wf = self.Wf[:, :n0, :m0]
 

--- a/turbustat/statistics/wavelets/wavelet_transform.py
+++ b/turbustat/statistics/wavelets/wavelet_transform.py
@@ -6,11 +6,7 @@ import warnings
 from astropy.convolution import convolve_fft, MexicanHat2DKernel
 import statsmodels.formula.api as sm
 from pandas import Series, DataFrame
-
-try:
-    from scipy.fftpack import fftn, ifftn, fftfreq
-except ImportError:
-    from numpy.fft import fftn, ifftn, fftfreq
+from numpy.fft import fftn, ifftn, fftfreq
 
 
 class Mexican_hat():

--- a/turbustat/statistics/wavelets/wavelet_transform.py
+++ b/turbustat/statistics/wavelets/wavelet_transform.py
@@ -125,7 +125,7 @@ class wt2D(object):
         l, k = fftfreq(N, self.dy), fftfreq(M, self.dx)
 
         # Calculates the Fourier transform of the input signal.
-        f_ft = fftn(self.array, shape=(N, M))
+        f_ft = fftn(self.array)
         # Creates empty wavelet transform array and fills it for every discrete
         # scale using the convolution theorem.
         self.Wf = np.zeros((A, N, M), 'complex')

--- a/turbustat/tests/test_rfft_to_fft.py
+++ b/turbustat/tests/test_rfft_to_fft.py
@@ -1,0 +1,28 @@
+
+from turbustat.statistics.rfft_to_fft import rfft_to_fft
+from ._testing_data import dataset1
+
+
+import numpy as np
+import numpy.testing as npt
+from unittest import TestCase
+
+
+class testRFFT(TestCase):
+    """docstring for testRFFT"""
+    def __init__(self):
+        self.dataset1 = dataset1
+
+        self.comp_rfft = rfft_to_fft(self.dataset1)
+
+    def rfft_to_rfft(self):
+        test_rfft = np.abs(np.fft.rfftn(self.dataset1))
+
+        shape2 = test_rfft.shape[-1]
+
+        npt.assert_allclose(test_rfft, self.comp_rfft[:, :, :shape2+1])
+
+    def fft_to_rfft(self):
+        test_fft = np.abs(np.fft.fftn(self.dataset1))
+
+        npt.assert_allclose(test_fft, self.comp_rfft)


### PR DESCRIPTION
Switch to using numpy fft functions.

Most methods only require the absolute value of the fft, so memory can be saved by computing the rfft, then expanding to reproduce the output of fft.

Added tests for the rfft to fft output.