### PR TITLE
Updates to some examples scripts; Change numpy version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     - source activate test
 
     # Now install dependencies
-    - conda install --yes numpy==1.10.0
+    - conda install --yes numpy==1.9.0
     - conda install --yes scipy
     - conda install --yes matplotlib
     - conda install --yes pandas

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ install:
     - source activate test
 
     # Now install dependencies
-    - conda install --yes numpy
+    - conda install --yes numpy==1.10.0
     - conda install --yes scipy
     - conda install --yes matplotlib
     - conda install --yes pandas
     - conda install --yes statsmodels
     - conda install --yes scikit-learn
-    - conda install --yes astropy==0.4rc1
+    - conda install --yes astropy
 
     # Use pip to install development versions
     - pip install git+https://github.com/dendrograms/astrodendro.git

--- a/Examples/analysis_pipeline.py
+++ b/Examples/analysis_pipeline.py
@@ -150,8 +150,17 @@ statistics_list.remove("PDF_AD")
 effect_plots("DataforFits.csv", "ResultsFactorial.csv", save=True,
              out_path='Model Plots/')
 
-map_all_results("ResultsFactorial.csv", normed=True, max_order=2,
+# Only show results of the good statistics
+good_stats = ["Cramer", "DeltaVariance", "Dendrogram_Hist",
+              "Dendrogram_Num", "PCA", "PDF_Hellinger", "SCF", "VCA", "VCS",
+              "VCS_Density", "VCS_Velocity", "Skewness", "Kurtosis"]
+
+# THE ASPECT RATIO IS FUNKY
+# NEED TO ADJUST BY HAND
+# Use: p.ion(), and set save_name=None to alter by-hand
+
+map_all_results("ResultsFactorial.csv", normed=False, max_order=2,
                 save_name="map_all_results.pdf",
-                out_path='Model Plots/')
+                out_path='Model Plots/', statistics=good_stats)
 
 print "Finished!"

--- a/Examples/effect_plots.py
+++ b/Examples/effect_plots.py
@@ -253,7 +253,6 @@ def map_all_results(effects_file, min_zscore=2.0, save_name=None,
                          10,
                          2)
 
-    p.figure(figsize=(16, 7))
     p.imshow(values, vmin=0, vmax=10, cmap=milagro,
              interpolation="nearest")
     p.xticks(np.arange(len(model_effects)), model_effects, rotation=90,
@@ -265,6 +264,7 @@ def map_all_results(effects_file, min_zscore=2.0, save_name=None,
     # Avoid white lines in the pdf rendering
     cbar.solids.set_edgecolor("face")
 
+    p.axes().set_aspect('auto')
     p.tight_layout()
 
     # Save if save_name has been given

--- a/Examples/effect_plots.py
+++ b/Examples/effect_plots.py
@@ -256,11 +256,11 @@ def map_all_results(effects_file, min_zscore=2.0, save_name=None,
     p.imshow(values, vmin=0, vmax=10, cmap=milagro,
              interpolation="nearest")
     p.xticks(np.arange(len(model_effects)), model_effects, rotation=90,
-             fontsize=18)
-    p.yticks(np.arange(len(statistics)), stat_labels, fontsize=18)
+             fontsize=24)
+    p.yticks(np.arange(len(statistics)), stat_labels, fontsize=24)
     cbar = p.colorbar(fraction=0.05, shrink=0.9)
-    cbar.ax.set_ylabel(r'$t$-value', size=18)
-    cbar.ax.tick_params(labelsize=18)
+    cbar.ax.set_ylabel(r'$t$-value', size=24)
+    cbar.ax.tick_params(labelsize=24)
     # Avoid white lines in the pdf rendering
     cbar.solids.set_edgecolor("face")
 

--- a/Examples/make_distance_plots.py
+++ b/Examples/make_distance_plots.py
@@ -48,7 +48,7 @@ comparison_plot(
     num_fids=5, design_matrix=design_matrix, obs_to_fid=True, legend=False,
     obs_legend=True,
     statistics=["Cramer", "DeltaVariance", "Dendrogram_Hist",
-                "Dendrogram_Num", "PCA", "PDF_Hellinger", "SCF", "VCA", "VCS",
+                "Dendrogram_Num", "PCA", "SCF", "VCA", "VCS",
                 "VCS_Density", "VCS_Velocity", "Skewness", "Kurtosis"])
 
 # Des to Obs
@@ -60,7 +60,7 @@ comparison_plot(
     des_to_obs_path, comparisons=des_to_obs_comparisons,
     out_path=os.path.join(des_to_obs_path, "Distance Plots"),
     num_fids=3, design_matrix=design_matrix,
-    legend_labels=["Oph A", "IC 348", "NGC 1333"],
+    legend_labels=["IC 348", "NGC 1333", "Oph A"],
     statistics=["Cramer", "DeltaVariance", "Dendrogram_Hist",
-                "Dendrogram_Num", "PCA", "PDF_Hellinger", "SCF", "VCA", "VCS",
+                "Dendrogram_Num", "PCA", "SCF", "VCA", "VCS",
                 "VCS_Density", "VCS_Velocity", "Skewness", "Kurtosis"])

--- a/Examples/make_distance_plots.py
+++ b/Examples/make_distance_plots.py
@@ -60,7 +60,7 @@ comparison_plot(
     des_to_obs_path, comparisons=des_to_obs_comparisons,
     out_path=os.path.join(des_to_obs_path, "Distance Plots"),
     num_fids=3, design_matrix=design_matrix,
-    legend_labels=["IC 348", "NGC 1333", "Oph A"],
+    legend_labels=["Oph A", "IC 348", "NGC 1333"],
     statistics=["Cramer", "DeltaVariance", "Dendrogram_Hist",
                 "Dendrogram_Num", "PCA", "SCF", "VCA", "VCS",
                 "VCS_Density", "VCS_Velocity", "Skewness", "Kurtosis"])

--- a/Examples/make_distance_plots.py
+++ b/Examples/make_distance_plots.py
@@ -46,9 +46,10 @@ comparison_plot(
     obs_to_fid_path, comparisons=obs_to_fid_comparisons,
     out_path=os.path.join(obs_to_fid_path, "Distance Plots"),
     num_fids=5, design_matrix=design_matrix, obs_to_fid=True, legend=False,
+    obs_legend=True,
     statistics=["Cramer", "DeltaVariance", "Dendrogram_Hist",
                 "Dendrogram_Num", "PCA", "PDF_Hellinger", "SCF", "VCA", "VCS",
-                "VCS_Density", "VCS_Velocity"])
+                "VCS_Density", "VCS_Velocity", "Skewness", "Kurtosis"])
 
 # Des to Obs
 
@@ -62,4 +63,4 @@ comparison_plot(
     legend_labels=["Oph A", "IC 348", "NGC 1333"],
     statistics=["Cramer", "DeltaVariance", "Dendrogram_Hist",
                 "Dendrogram_Num", "PCA", "PDF_Hellinger", "SCF", "VCA", "VCS",
-                "VCS_Density", "VCS_Velocity"])
+                "VCS_Density", "VCS_Velocity", "Skewness", "Kurtosis"])

--- a/Examples/make_obs_tables.py
+++ b/Examples/make_obs_tables.py
@@ -1,0 +1,38 @@
+
+# Create data tables of the observational results
+# Run from Dropbox/AstroStatistics/Full Factorial/Observational Results/
+
+import os
+import shutil
+
+from turbustat.analysis.convert_results import concat_convert_HDF5
+from turbustat.analysis import convert_format
+
+
+# Obs to Fids
+
+path = "Obs_to_Fid/"
+hdf5_path = "Obs_to_Fid/HDF5/"
+
+convert_format(hdf5_path, 0)
+shutil.move(hdf5_path+"complete_distances_face_0.csv", path)
+
+convert_format(hdf5_path, 1)
+shutil.move(hdf5_path+"complete_distances_face_1.csv", path)
+
+convert_format(hdf5_path, 2)
+shutil.move(hdf5_path+"complete_distances_face_2.csv", path)
+
+# Des to Obs
+
+hdf5_path = "Des_to_Obs/HDF5/"
+
+concat_convert_HDF5(hdf5_path, face=0, interweave=True, average_axis=0)
+shutil.move(os.path.join(hdf5_path, "des_0.csv"), "Des_to_Obs")
+shutil.move("Des_to_Obs/des_0.csv", "Des_to_Obs/des_0_obs.csv")
+
+concat_convert_HDF5(hdf5_path, face=2, interweave=True, average_axis=0)
+shutil.move(os.path.join(hdf5_path, "des_2.csv"), "Des_to_Obs")
+shutil.move("Des_to_Obs/des_2.csv", "Des_to_Obs/des_2_obs.csv")
+
+# Make plots using make_distance_plots.py

--- a/Examples/noise_validation.r
+++ b/Examples/noise_validation.r
@@ -4,7 +4,7 @@
 args = commandArgs(TRUE)
 
 startTime = Sys.time()
-setwd(args[1])
+# setwd(args[1])
 
 FidDes00 = read.csv('distances_0_0.csv', header = T)
 FidFid00 = read.csv('fiducials_0_0.csv', header = T)

--- a/Examples/signal_validation.r
+++ b/Examples/signal_validation.r
@@ -3,7 +3,7 @@
 args = commandArgs(TRUE)
 
 startTime = Sys.time()
-setwd(args[1])
+# setwd(args[1])
 
 FidDes00 = read.csv('distances_0_0.csv', header = T)
 FidDes22 = read.csv('distances_2_2.csv', header = T)

--- a/turbustat/analysis/comparison_plot.py
+++ b/turbustat/analysis/comparison_plot.py
@@ -314,11 +314,11 @@ def _plotter(ax, data, fid_data, num_fids, title, stat, bottom, left,
     if legend:
         ax.legend(loc="upper right", prop={'size': 10})
     if labels is None:
-        ax.set_xlim([-1, num_design + num_fids + 5])
+        ax.set_xlim([-1, num_design + num_fids + 8])
         ax.set_xticks(np.append(x_vals, x_fid_vals))
         ax.set_xticklabels(xtick_labels+fid_labels, rotation=90, size=12)
     else:
-        ax.set_xlim([-2, num_design + num_fids + 5])
+        ax.set_xlim([-2, num_design + num_fids + 8])
         xticks = np.append([-1], np.append(x_vals, x_fid_vals))
         ax.set_xticks(xticks)
         ax.set_xticklabels(labels+fid_labels, rotation=90, size=12)

--- a/turbustat/analysis/comparison_plot.py
+++ b/turbustat/analysis/comparison_plot.py
@@ -271,9 +271,10 @@ def _plotter(ax, data, fid_data, num_fids, title, stat, bottom, left,
             ax.plot(x_vals, y_vals, "-o", label="Fiducial " + str(i),
                     alpha=0.6)
     # Set title in upper left hand corner
-    ax.annotate(title, xy=(0, 1), xytext=(12, -6), va='top',
-                xycoords='axes fraction', textcoords='offset points',
-                fontsize=12, alpha=0.75)
+    ax.set_title(title, fontsize=12)
+    # ax.annotate(title, xy=(1, 0), xytext=(0.9, 0.05), va='top',
+    #             xycoords='axes fraction', textcoords='axes fraction',
+    #             fontsize=12, alpha=0.75)
     if left:
         # Set the ylabel using the stat name. Replace underscores
         ax.set_ylabel(stat.replace("_", " ")+"\nDistance", fontsize=10,

--- a/turbustat/analysis/comparison_plot.py
+++ b/turbustat/analysis/comparison_plot.py
@@ -339,7 +339,7 @@ def _horiz_obs_plot(ax, data, num_fids, shading=False, legend=False):
                    "ic348.13co.fits": "IC 348"}
 
     # Also needs to be generalized
-    colors = ["r", "g", "b"]
+    colors = ["b", "g", "r"]
 
     x_vals = ax.axis()[:2]
 

--- a/turbustat/analysis/comparison_plot.py
+++ b/turbustat/analysis/comparison_plot.py
@@ -339,7 +339,7 @@ def _horiz_obs_plot(ax, data, num_fids, shading=False, legend=False):
                    "ic348.13co.fits": "IC 348"}
 
     # Also needs to be generalized
-    colors = ["b", "g", "r"]
+    colors = ["g", "r", "b"]
 
     x_vals = ax.axis()[:2]
 


### PR DESCRIPTION
Brings the examples scripts for the paper up to date.

Testing on travis started to fail as a result of the newest numpy version. Seems to be an issue with skimage playing nicely with the new numpy. Some versions were altered for this reason. Hopefully, once the other packages have fixes, this can be removed. Support for python 2.6 will probably be dropped at that time.