### PR TITLE
Angular units

### DIFF
--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -159,7 +159,7 @@ class StatisticBase_PSpec2D(object):
         return self._slope_err
 
     def plot_fit(self, show=True, show_2D=False, color='r', label=None,
-                 symbol="D", ang_units=False, unit=u.arcsec):
+                 symbol="D", ang_units=False, unit=u.deg):
         '''
         Plot the fitted model.
         '''

--- a/turbustat/statistics/base_statistic.py
+++ b/turbustat/statistics/base_statistic.py
@@ -1,5 +1,6 @@
 
 from astropy.io import fits
+import astropy.units as u
 import numpy as np
 
 from ..io import input_data
@@ -57,3 +58,12 @@ class BaseStatisticMixIn(object):
             self.header = header
         else:
             self.data, self.header = input_data(data)
+
+    @property
+    def angular_equiv(self):
+        return [(u.pix, u.deg, lambda x: x * float(self.ang_size.value),
+                lambda x: x / float(self.ang_size.value))]
+
+    @property
+    def ang_size(self):
+        return np.abs(self.header["CDELT2"]) * u.deg

--- a/turbustat/statistics/scf/scf.py
+++ b/turbustat/statistics/scf/scf.py
@@ -118,8 +118,7 @@ class SCF(BaseStatisticMixIn):
                       return_freqs=False, **kwargs)
             self._stddev_flag = False
 
-        if self.ang_units:
-            self._lags *= np.abs(self.header["CDELT2"])
+        self._lags = self._lags * u.pix
 
     def save_results(self, output_name=None, keep_data=False):
         '''

--- a/turbustat/statistics/scf/scf.py
+++ b/turbustat/statistics/scf/scf.py
@@ -4,6 +4,7 @@
 import numpy as np
 import cPickle as pickle
 from copy import deepcopy
+from astropy import units as u
 
 from ..psds import pspec
 from ..base_statistic import BaseStatisticMixIn
@@ -23,13 +24,11 @@ class SCF(BaseStatisticMixIn):
         Header for the cube.
     size : int, optional
         Maximum size roll over which SCF will be calculated.
-    ang_units : bool, optional
-        Convert the lags to angular units using the given header.
     '''
 
     __doc__ %= {"dtypes": " or ".join(common_types + threed_types)}
 
-    def __init__(self, cube, header=None, size=11, ang_units=False):
+    def __init__(self, cube, header=None, size=11):
         super(SCF, self).__init__()
 
         # Set data and header
@@ -44,8 +43,6 @@ class SCF(BaseStatisticMixIn):
 
         self._scf_surface = None
         self._scf_spectrum_stddev = None
-
-        self.ang_units = ang_units
 
     @property
     def scf_surface(self):
@@ -180,7 +177,8 @@ class SCF(BaseStatisticMixIn):
         return self
 
     def run(self, logspacing=False, return_stddev=False, verbose=False,
-            save_results=False, output_name=None):
+            save_results=False, output_name=None, ang_units=False,
+            unit=u.deg):
         '''
         Computes the SCF. Necessary to maintain package standards.
 
@@ -196,6 +194,10 @@ class SCF(BaseStatisticMixIn):
             Pickle the results.
         output_name : str, optional
             Name of the outputted pickle file.
+        ang_units : bool, optional
+            Convert frequencies to angular units using the given header.
+        unit : u.Unit, optional
+            Choose the angular unit to convert to when ang_units is enabled.
         '''
 
         self.compute_surface()
@@ -218,8 +220,14 @@ class SCF(BaseStatisticMixIn):
             p.xlabel("SCF Value")
 
             ax = p.subplot(2, 2, 4)
+            if ang_units:
+                lags = \
+                    self.lags.to(unit, equivalencies=self.angular_equiv).value
+            else:
+                lags = self.lags.value
+
             if self._stddev_flag:
-                ax.errorbar(self.lags, self.scf_spectrum,
+                ax.errorbar(lags, self.scf_spectrum,
                             yerr=self.scf_spectrum_stddev,
                             fmt='D-', color='k', markersize=5)
                 ax.set_xscale("log", nonposy='clip')
@@ -227,10 +235,10 @@ class SCF(BaseStatisticMixIn):
                 p.semilogx(self.lags, self.scf_spectrum, 'kD-',
                            markersize=5)
 
-            if self.ang_units:
-                ax.set_xlabel("Lag (deg)")
+            if ang_units:
+                ax.set_xlabel("Lag ("+unit.to_string()+")")
             else:
-                ax.set_xlabel("Lag (pixel)")
+                ax.set_xlabel("Lag (pixels)")
 
             p.tight_layout()
             p.show()
@@ -255,14 +263,12 @@ class SCF_Distance(object):
         Computed SCF object. Use to avoid recomputing.
     weighted : bool, optional
         Sets whether to apply the 1/r^2 weighting to the distance.
-    ang_units : bool, optional
-        Convert the lags to angular units using the given header.
     '''
 
     __doc__ %= {"dtypes": " or ".join(common_types + threed_types)}
 
     def __init__(self, cube1, cube2, size=21, fiducial_model=None,
-                 weighted=True, ang_units=False):
+                 weighted=True):
         super(SCF_Distance, self).__init__()
         self.size = size
         self.weighted = weighted
@@ -270,15 +276,14 @@ class SCF_Distance(object):
         if fiducial_model is not None:
             self.scf1 = fiducial_model
         else:
-            self.scf1 = SCF(cube1, size=self.size,
-                            ang_units=ang_units)
+            self.scf1 = SCF(cube1, size=self.size)
             self.scf1.run(return_stddev=True)
 
-        self.scf2 = SCF(cube2, size=self.size,
-                        ang_units=ang_units)
+        self.scf2 = SCF(cube2, size=self.size)
         self.scf2.run(return_stddev=True)
 
-    def distance_metric(self, verbose=False, label1=None, label2=None):
+    def distance_metric(self, verbose=False, label1=None, label2=None,
+                        ang_units=False, unit=u.deg):
         '''
         Compute the distance between the surfaces.
 
@@ -290,6 +295,10 @@ class SCF_Distance(object):
             Object or region name for cube1
         label2 : str, optional
             Object or region name for cube2
+        ang_units : bool, optional
+            Convert frequencies to angular units using the given header.
+        unit : u.Unit, optional
+            Choose the angular unit to convert to when ang_units is enabled.
         '''
 
         dx = np.arange(self.size) - self.size / 2
@@ -329,10 +338,21 @@ class SCF_Distance(object):
             p.title("Weighted Difference")
             p.colorbar()
             ax = p.subplot(2, 2, 4)
-            ax.errorbar(self.scf1.lags, self.scf1.scf_spectrum,
+            if ang_units:
+                lags1 = \
+                    self.scf1.lags.to(unit,
+                                      equivalencies=self.scf1.angular_equiv).value
+                lags2 = \
+                    self.scf2.lags.to(unit,
+                                      equivalencies=self.scf2.angular_equiv).value
+            else:
+                lags1 = self.scf1.lags.value
+                lags2 = self.scf2.lags.value
+
+            ax.errorbar(lags1, self.scf1.scf_spectrum,
                         yerr=self.scf1.scf_spectrum_stddev,
                         fmt='D-', color='b', markersize=5, label=label1)
-            ax.errorbar(self.scf2.lags, self.scf2.scf_spectrum,
+            ax.errorbar(lags2, self.scf2.scf_spectrum,
                         yerr=self.scf2.scf_spectrum_stddev,
                         fmt='o-', color='g', markersize=5, label=label2)
             ax.set_xscale("log", nonposy='clip')

--- a/turbustat/statistics/vca_vcs/vca.py
+++ b/turbustat/statistics/vca_vcs/vca.py
@@ -4,6 +4,7 @@
 import numpy as np
 import warnings
 from numpy.fft import fftshift
+import astropy.units as u
 
 from ..rfft_to_fft import rfft_to_fft
 from slice_thickness import change_slice_thickness
@@ -25,13 +26,11 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
         Corresponding FITS header.
     slice_sizes : float or int, optional
         Slices to degrade the cube to.
-    ang_units : bool, optional
-        Convert frequencies to angular units using the given header.
     '''
 
     __doc__ %= {"dtypes": " or ".join(common_types + threed_types)}
 
-    def __init__(self, cube, header=None, slice_size=None, ang_units=False):
+    def __init__(self, cube, header=None, slice_size=None):
         super(VCA, self).__init__()
 
         self.input_data_header(cube, header)
@@ -47,8 +46,6 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
                 change_slice_thickness(self.data,
                                        slice_thickness=self.slice_size)
 
-        self.ang_units = ang_units
-
         self._ps1D_stddev = None
 
     def compute_pspec(self):
@@ -61,7 +58,7 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
         self._ps2D = np.power(vca_fft, 2.).sum(axis=0)
 
     def run(self, verbose=False, brk=None, return_stddev=True,
-            logspacing=True):
+            logspacing=True, ang_units=False, unit=u.deg):
         '''
         Full computation of VCA.
 
@@ -75,6 +72,10 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
             Return the standard deviation in the 1D bins.
         logspacing : bool, optional
             Return logarithmically spaced bins for the lags.
+        ang_units : bool, optional
+            Convert frequencies to angular units using the given header.
+        unit : u.Unit, optional
+            Choose the angular unit to convert to when ang_units is enabled.
         '''
 
         self.compute_pspec()
@@ -85,7 +86,8 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
 
             print self.fit.summary()
 
-            self.plot_fit(show=True, show_2D=True)
+            self.plot_fit(show=True, show_2D=True, ang_units=ang_units,
+                          unit=unit)
 
         return self
 
@@ -110,17 +112,13 @@ class VCA_Distance(object):
         spline. If not specified, no break point will be used.
     fiducial_model : VCA
         Computed VCA object. use to avoid recomputing.
-    ang_units : bool, optional
-        Convert frequencies to angular units using the given header.
     '''
 
     __doc__ %= {"dtypes": " or ".join(common_types + threed_types)}
 
     def __init__(self, cube1, cube2, slice_size=1.0, breaks=None,
-                 fiducial_model=None, ang_units=False):
+                 fiducial_model=None):
         super(VCA_Distance, self).__init__()
-
-        self.ang_units = ang_units
 
         assert isinstance(slice_size, float)
 
@@ -131,14 +129,13 @@ class VCA_Distance(object):
             self.vca1 = fiducial_model
         else:
             self.vca1 = \
-                VCA(cube1, slice_size=slice_size,
-                    ang_units=ang_units).run(brk=breaks[0])
+                VCA(cube1, slice_size=slice_size).run(brk=breaks[0])
 
         self.vca2 = \
-            VCA(cube2, slice_size=slice_size,
-                ang_units=ang_units).run(brk=breaks[1])
+            VCA(cube2, slice_size=slice_size).run(brk=breaks[1])
 
-    def distance_metric(self, verbose=False, label1=None, label2=None):
+    def distance_metric(self, verbose=False, label1=None, label2=None,
+                        ang_units=False, unit=u.deg):
         '''
 
         Implements the distance metric for 2 VCA transforms, each with the
@@ -153,6 +150,10 @@ class VCA_Distance(object):
             Object or region name for cube1
         label2 : str, optional
             Object or region name for cube2
+        ang_units : bool, optional
+            Convert frequencies to angular units using the given header.
+        unit : u.Unit, optional
+            Choose the angular unit to convert to when ang_units is enabled.
         '''
 
         # Construct t-statistic
@@ -169,8 +170,10 @@ class VCA_Distance(object):
             print self.vca2.fit.summary()
 
             import matplotlib.pyplot as p
-            self.vca1.plot_fit(show=False, color='b', label=label1, symbol='D')
-            self.vca2.plot_fit(show=False, color='g', label=label2, symbol='o')
+            self.vca1.plot_fit(show=False, color='b', label=label1, symbol='D',
+                               ang_units=ang_units, unit=unit)
+            self.vca2.plot_fit(show=False, color='g', label=label2, symbol='o',
+                               ang_units=ang_units, unit=unit)
             p.legend(loc='upper right')
             p.show()
 


### PR DESCRIPTION
Corrects the use of angular spatial scales and frequencies in a number of methods.

All spatial scales and frequencies are given as `astropy.Quantity` objects in pixel units.

Plotting in angular units is enabled by setting `ang_units=True` in the `run` or `distance_metric` functions. The angular unit can be changed by altering `unit=u.deg` in `run` or `distance_metric`.