### PR TITLE
Ensure finite break points

### DIFF
--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -63,7 +63,7 @@ class StatisticBase_PSpec2D(object):
         # Attach units to freqs
         self._freqs = self.freqs / u.pix
 
-    def fit_pspec(self, brk=None, log_break=False, low_cut=None,
+    def fit_pspec(self, brk=None, log_break=True, low_cut=None,
                   high_cut=None, min_fits_pts=10, verbose=False,
                   large_scale=1.):
         '''

--- a/turbustat/statistics/lm_seg.py
+++ b/turbustat/statistics/lm_seg.py
@@ -42,6 +42,9 @@ class Lm_Seg(object):
         self.y = y
         self.brk = brk
 
+        if not np.isfinite(self.brk):
+            raise ValueError("brk must be a finite value.")
+
         # Make sure the starting break point is in range of the data
         if not (self.x > self.brk).any():
             raise ValueError("brk is outside the range.")


### PR DESCRIPTION
`Lm_Seg` raises a more clear error message when the given break point is not finite.

The break point in the 2D Power spectrum methods assumes the value is in log-scale (ie. `log_break=True` by default).