### PR TITLE
Bispectrum nsamples input fix

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #112 - Stop importing everything at the top level of the module. Also fixes minor input bugs in BiSpectrum_Distance and registers "check_deps" as a command for setup.py.
 * #109 - Limit VCA spectrum frequencies below 0.5.
 * #106 - Support for multiple data inputs (FITS HDU, SpectralCube, etc). Switched to pytest.
 * #105 - Bug in wrapper function. Added test for wrapper.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ def check_dependencies():
             "Install or upgrade scipy before installing TurbuStat.")
 
     try:
-        from pandas.version import version as pa_version
+        import pandas
+        pa_version = pandas.__version__
         if parse_version(pa_version) < parse_version('0.13'):
             print("***Before installing, upgrade pandas to 0.13***")
             raise ImportError
@@ -145,6 +146,7 @@ if __name__ == "__main__":
     # invoking any other functionality from distutils since it can potentially
     # modify distutils' behavior.
     cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
+    cmdclassd['check_deps'] = check_deps
 
     # Adjust the compiler in case the default on this platform is to use a
     # broken one.

--- a/turbustat/__init__.py
+++ b/turbustat/__init__.py
@@ -1,10 +1,9 @@
 
 from ._astropy_init import *
 
-if not _ASTROPY_SETUP_:
-    from .statistics import *
-    from .analysis import *
-    # from .cube_tools import *
-    from .data_reduction import *
-    from .io import *
-    from .statistics import *
+# if not _ASTROPY_SETUP_:
+#     from .statistics import *
+#     from .analysis import *
+#     # from .cube_tools import *
+#     from .data_reduction import *
+#     from .io import *

--- a/turbustat/statistics/pspec_bispec/pspec_bispec.py
+++ b/turbustat/statistics/pspec_bispec/pspec_bispec.py
@@ -344,10 +344,10 @@ class BiSpectrum_Distance(object):
             self.bispec1 = fiducial_model
         else:
             self.bispec1 = BiSpectrum(data1)
-            self.bispec1.run()
+            self.bispec1.run(nsamples=nsamples)
 
         self.bispec2 = BiSpectrum(data2)
-        self.bispec2.run()
+        self.bispec2.run(nsamples=nsamples)
 
         self.distance = None
 

--- a/turbustat/statistics/pspec_bispec/pspec_bispec.py
+++ b/turbustat/statistics/pspec_bispec/pspec_bispec.py
@@ -343,10 +343,10 @@ class BiSpectrum_Distance(object):
         if fiducial_model is not None:
             self.bispec1 = fiducial_model
         else:
-            self.bispec1 = BiSpectrum(data1[0])
+            self.bispec1 = BiSpectrum(data1)
             self.bispec1.run()
 
-        self.bispec2 = BiSpectrum(data2[0])
+        self.bispec2 = BiSpectrum(data2)
         self.bispec2.run()
 
         self.distance = None

--- a/turbustat/statistics/pspec_bispec/pspec_bispec.py
+++ b/turbustat/statistics/pspec_bispec/pspec_bispec.py
@@ -219,7 +219,8 @@ class BiSpectrum(BaseStatisticMixIn):
         # Set nans to min
         self.data[np.isnan(self.data)] = np.nanmin(self.data)
 
-    def compute_bispectrum(self, nsamples=100, seed=1000):
+    def compute_bispectrum(self, nsamples=100, seed=1000,
+                           mean_subract=False):
         '''
         Do the computation.
 
@@ -232,7 +233,12 @@ class BiSpectrum(BaseStatisticMixIn):
             Sets the seed for the distribution draws.
         '''
 
-        fftarr = np.fft.fft2(self.data)
+        if mean_subract:
+            norm_data = self.data - self.data.mean()
+        else:
+            norm_data = self.data
+
+        fftarr = np.fft.fft2(norm_data)
         conjfft = np.conj(fftarr)
         ra.seed(seed)
 


### PR DESCRIPTION
The `nsamples` kwarg for `BiSpectrum_Distance` was not actually being passed. Now you can sample as much as you want!

Also fixes an issue when passing a FITS hdu to `BiSpectrum_Distance`, stops everything from being imported at the top level of the package, and register `check_deps` to check whether all package dependencies are installed (i.e., run `python setup.py check_deps`).