### PR TITLE
VCS physical units bug

### DIFF
--- a/turbustat/statistics/vca_vcs/vcs.py
+++ b/turbustat/statistics/vca_vcs/vcs.py
@@ -293,9 +293,9 @@ class VCS_Distance(object):
             print(self.vcs2.fit.fit.summary())
 
             if self.vel_units:
-                xlab = r"log k$_v$/$(km^{-1}s)$"
+                xlab = r"log $\left( k_v / (\mathrm{km}/\mathrm{s})^{-1} \right)$"
             else:
-                xlab = r"log k$_v$/pixel$^{-1}$"
+                xlab = r"log k$_v$ / pixel$^{-1}$"
 
             import matplotlib.pyplot as p
             p.plot(self.vcs1.fit.x, self.vcs1.fit.y, 'bD', alpha=0.5,

--- a/turbustat/statistics/vca_vcs/vcs.py
+++ b/turbustat/statistics/vca_vcs/vcs.py
@@ -46,7 +46,7 @@ class VCS(BaseStatisticMixIn):
 
         if vel_units:
             try:
-                spec_unit = u.Unit(header["CUNIT3"])
+                spec_unit = u.Unit(self.header["CUNIT3"])
                 self.vel_to_pix = (np.abs(self.header["CDELT3"]) *
                                    spec_unit).to(u.km/u.s).value
             except (KeyError, u.UnitsError) as e:

--- a/turbustat/statistics/vca_vcs/vcs.py
+++ b/turbustat/statistics/vca_vcs/vcs.py
@@ -295,7 +295,7 @@ class VCS_Distance(object):
             if self.vel_units:
                 xlab = r"log $\left( k_v / (\mathrm{km}/\mathrm{s})^{-1} \right)$"
             else:
-                xlab = r"log k$_v$ / pixel$^{-1}$"
+                xlab = r"log $\left( k_v / \mathrm{pixel}^{-1} \right)$"
 
             import matplotlib.pyplot as p
             p.plot(self.vcs1.fit.x, self.vcs1.fit.y, 'bD', alpha=0.5,


### PR DESCRIPTION
Force to use `self.header`, since `header` need not be set.

Make the VCS frequency axis labels more clear.