### PR TITLE
Refining the required and optional packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,16 @@ Requires:
  *   sklearn-0.13.0
  *   pandas-0.13
  *   statsmodels-0.4.0
- *   astrodendro-dev
- *   [signal-id](https://github.com/radio-astro-tools/signal-id)
+
+Recommended:
+
  *   [spectral-cube](https://github.com/radio-astro-tools/spectral-cube)
+ *   [radio_beam](https://github.com/radio-astro-tools/radio_beam)
+ *   [astrodendro-development](https://github.com/dendrograms/astrodendro)
+
+Optional:
+ *   [signal-id](https://github.com/radio-astro-tools/signal-id)
+
 
 Credits
 -------

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Requires:
 
 Recommended:
 
- *   [spectral-cube](https://github.com/radio-astro-tools/spectral-cube)
- *   [radio_beam](https://github.com/radio-astro-tools/radio_beam)
- *   [astrodendro-development](https://github.com/dendrograms/astrodendro)
+ *   [spectral-cube](https://github.com/radio-astro-tools/spectral-cube) - Efficient handling of PPV cubes. Required for calculating moment arrays in `turbustat.data_reduction.Mask_and_Moments`
+ *   [astrodendro-development](https://github.com/dendrograms/astrodendro) - Required for calculating dendrograms in `turbustat.statistics.dendrograms`
 
 Optional:
- *   [signal-id](https://github.com/radio-astro-tools/signal-id)
+ *   [signal-id](https://github.com/radio-astro-tools/signal-id) - Noise estimation in PPV cubes.
+ *   [radio_beam](https://github.com/radio-astro-tools/radio_beam) - A class for handling radio beams and useful utilities. Used for noise estimation in signal-id
 
 
 Credits

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Requires:
  *   sklearn>=0.13.0
  *   pandas>=0.13
  *   statsmodels>=0.4.0
+ *   [spectral-cube](https://github.com/radio-astro-tools/spectral-cube)
 
 Recommended:
 
- *   [spectral-cube](https://github.com/radio-astro-tools/spectral-cube)
  *   [radio_beam](https://github.com/radio-astro-tools/radio_beam)
  *   [astrodendro-development](https://github.com/dendrograms/astrodendro)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Package Dependencies
 
 Requires:
 
+ *   astropy>=1.0
+ *   numpy>=1.7
  *   matplotlib>=1.2
  *   scipy>=0.12
  *   sklearn>=0.13.0

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Package Dependencies
 
 Requires:
 
- *   matplotlib-1.2
- *   scipy-0.12
- *   sklearn-0.13.0
- *   pandas-0.13
- *   statsmodels-0.4.0
+ *   matplotlib>=1.2
+ *   scipy>=0.12
+ *   sklearn>=0.13.0
+ *   pandas>=0.13
+ *   statsmodels>=0.4.0
 
 Recommended:
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Requires:
  *   sklearn>=0.13.0
  *   pandas>=0.13
  *   statsmodels>=0.4.0
- *   [spectral-cube](https://github.com/radio-astro-tools/spectral-cube)
 
 Recommended:
 
+ *   [spectral-cube](https://github.com/radio-astro-tools/spectral-cube)
  *   [radio_beam](https://github.com/radio-astro-tools/radio_beam)
  *   [astrodendro-development](https://github.com/dendrograms/astrodendro)
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,18 +5,23 @@ Installing TurbuStat
 TurbuStat is currently only available from the `github repo <https://github.com/Astroua/TurbuStat>`_.
 
 TurbuStat requires the follow packages:
- * numpy-1.6
- * matplotlib
- * astropy-1.0
- * scipy-0.12.0
- * sklearn-0.13.0
- * pandas-0.13
- * statsmodels-0.4.0
- * astrodendro-`dev <https://github.com/dendrograms/astrodendro>`_
- * `spectral-cube-v0.2.2 <https://github.com/radio-astro-tools/spectral-cube>`_
- * `signal-id <https://github.com/radio-astro-tools/signal-id>`_
 
- We recommend installing the `radio_beam <https://github.com/radio-astro-tools/radio_beam>`_ package to aid in the noise estimation in `signal-id <https://github.com/radio-astro-tools/signal-id>`_.
+ *   astropy>=1.0
+ *   numpy>=1.7
+ *   matplotlib>=1.2
+ *   scipy>=0.12
+ *   sklearn>=0.13.0
+ *   pandas>=0.13
+ *   statsmodels>=0.4.0
+
+The following packages are optional, but required for specific functions in TurbuStat:
+
+ *   `spectral-cube <https://github.com/radio-astro-tools/spectral-cube>`_ - Efficient handling of PPV cubes. Required for calculating moment arrays in `turbustat.data_reduction.Mask_and_Moments`
+ *   `astrodendro-development <https://github.com/dendrograms/astrodendro>`_ - Required for calculating dendrograms in `turbustat.statistics.dendrograms`
+
+When using `turbustat.data_reduction.Mask_and_Moments`, the noise can be automatically estimated by installing two additional packages (**IN DEVELOPMENT**):
+ *   `signal-id <https://github.com/radio-astro-tools/signal-id>`_ - Noise estimation in PPV cubes.
+ *   `radio_beam <https://github.com/radio-astro-tools/radio_beam>`_ - A class for handling radio beams and useful utilities. Used for noise estimation in signal-id
 
  To install the packages, clone the repository:
  ::

--- a/turbustat/data_reduction/make_moments.py
+++ b/turbustat/data_reduction/make_moments.py
@@ -1,6 +1,4 @@
 
-from spectral_cube import SpectralCube, LazyMask
-from spectral_cube.wcs_utils import drop_axis
 import numpy as np
 from astropy.io import fits
 from astropy.convolution import convolve
@@ -8,6 +6,15 @@ from scipy import ndimage as nd
 import itertools as it
 import operator as op
 import os
+
+try:
+    from spectral_cube import SpectralCube, LazyMask
+    from spectral_cube.wcs_utils import drop_axis
+    spectral_cube_flag = True
+except ImportError:
+    Warning("spectral-cube is not installed. Using Mask_and_Moments requires"
+            " spectral-cube to be installed.")
+    spectral_cube_flag = False
 
 try:
     from signal_id import Noise
@@ -46,6 +53,11 @@ class Mask_and_Moments(object):
                  moment_method='slice'):
         super(Mask_and_Moments, self).__init__()
 
+        if not spectral_cube_flag:
+            raise ImportError("Mask_and_Moments requires the spectral-cube "
+                              " to be installed: https://github.com/"
+                              "radio-astro-tools/spectral-cube")
+
         if isinstance(cube, SpectralCube):
             self.cube = cube
             self.save_name = None
@@ -63,8 +75,9 @@ class Mask_and_Moments(object):
 
         if scale is None:
             if not signal_id_flag:
-                raise ImportError("signal-id is not installed."
-                                  " You must provide the scale.")
+                raise ImportError("signal-id is not installed and error"
+                                  " estimation is not available. You must "
+                                  "provide the noise scale.")
 
             self.scale = Noise(self.cube).scale
         else:
@@ -379,6 +392,11 @@ class Mask_and_Moments(object):
             Filename of the integrated intensity array. Use if naming scheme
             is not valid for automatic loading.
         '''
+
+        if not spectral_cube_flag:
+            raise ImportError("Mask_and_Moments requires the spectral-cube "
+                              " to be installed: https://github.com/"
+                              "radio-astro-tools/spectral-cube")
 
         if moments_path is None:
             moments_path = ""


### PR DESCRIPTION
Makes it (hopefully) more clear which packages are required for TurbuStat.

Since `spectral_cube` is optional, errors are raised when trying to use `Mask_and_Moments` when it hasn't been installed.