### PR TITLE
SCF shifting

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #118 - Fix SCF surface indexing with non-integer shifts.
 * #117 - Use common angular scales for SCF, Moments, Delta-Variance comparison. Dropped using nanmean, nanstd from scipy.stats. Added fourier shifting for SCF.
 * #116 - Normalize Genus distance by the image area for comparing unequally-sized images
 * #115 - Alter the PCA and Genus metrics to more closely follow the rest of the suite.

--- a/turbustat/statistics/scf/scf.py
+++ b/turbustat/statistics/scf/scf.py
@@ -129,7 +129,9 @@ class SCF(BaseStatisticMixIn):
                       return_freqs=False, **kwargs)
             self._stddev_flag = False
 
-        self._lags = self._lags * u.pix
+        roll_lag_diff = np.abs(self.roll_lags[1] - self.roll_lags[0])
+
+        self._lags = self._lags * roll_lag_diff * u.pix
 
     def save_results(self, output_name=None, keep_data=False):
         '''

--- a/turbustat/statistics/scf/scf.py
+++ b/turbustat/statistics/scf/scf.py
@@ -84,18 +84,17 @@ class SCF(BaseStatisticMixIn):
         dx = self.roll_lags.copy()
         dy = self.roll_lags.copy()
 
-        for i in dx:
-            for j in dy:
-                tmp = fourier_shift(self.data, i, axis=1)
-                tmp = fourier_shift(tmp, j, axis=2)
+        for i, x_shift in enumerate(dx):
+            for j, y_shift in enumerate(dy):
+                tmp = fourier_shift(self.data, x_shift, axis=1)
+                tmp = fourier_shift(tmp, y_shift, axis=2)
                 values = np.nansum(((self.data - tmp) ** 2), axis=0) / \
                     (np.nansum(self.data ** 2, axis=0) +
                      np.nansum(tmp ** 2, axis=0))
 
                 scf_value = 1. - \
                     np.sqrt(np.nansum(values) / np.sum(np.isfinite(values)))
-                self._scf_surface[i + self.size / 2, j + self.size / 2] = \
-                    scf_value
+                self._scf_surface[i, j] = scf_value
 
     def compute_spectrum(self, logspacing=False, return_stddev=False,
                          **kwargs):

--- a/turbustat/tests/test_scf.py
+++ b/turbustat/tests/test_scf.py
@@ -45,4 +45,4 @@ class testSCF(TestCase):
         # at least less than this.
         fid_dist = 0.02
 
-        assert self.tester_dist_zoom < fid_dist
+        assert self.tester_dist_zoom.distance < fid_dist

--- a/turbustat/tests/test_scf.py
+++ b/turbustat/tests/test_scf.py
@@ -41,6 +41,8 @@ class testSCF(TestCase):
             SCF_Distance([cube, hdr], dataset1["cube"],
                          size=11).distance_metric(verbose=True)
 
+        # Based on the fiducial values, the distance should be
+        # at least less than this.
         fid_dist = 0.02
 
         assert self.tester_dist_zoom < fid_dist

--- a/turbustat/tests/test_scf.py
+++ b/turbustat/tests/test_scf.py
@@ -39,7 +39,7 @@ class testSCF(TestCase):
 
         self.tester_dist_zoom = \
             SCF_Distance([cube, hdr], dataset1["cube"],
-                         size=11).distance_metric(verbose=True)
+                         size=11).distance_metric()
 
         # Based on the fiducial values, the distance should be
         # at least less than this.

--- a/turbustat/tests/test_scf.py
+++ b/turbustat/tests/test_scf.py
@@ -24,6 +24,13 @@ class testSCF(TestCase):
 
         assert np.allclose(self.tester.scf_surface, computed_data['scf_val'])
 
+    def test_SCF_noninteger_shift(self):
+        # Not testing against anything, just make sure it runs w/o issue.
+        rolls = np.array([-4.5, -3.0, -1.5, 0, 1.5, 3.0, 4.5])
+        self.tester_nonint = \
+            SCF(dataset1["cube"], roll_lags=rolls)
+        self.tester_nonint.run()
+
     def test_SCF_distance(self):
         self.tester_dist = \
             SCF_Distance(dataset1["cube"],

--- a/turbustat/tests/test_scf.py
+++ b/turbustat/tests/test_scf.py
@@ -9,6 +9,7 @@ from unittest import TestCase
 
 import numpy as np
 import numpy.testing as npt
+from scipy.ndimage import zoom
 
 from ..statistics import SCF, SCF_Distance
 from ._testing_data import \
@@ -16,10 +17,6 @@ from ._testing_data import \
 
 
 class testSCF(TestCase):
-
-    def setUp(self):
-        self.dataset1 = dataset1
-        self.dataset2 = dataset2
 
     def test_SCF_method(self):
         self.tester = SCF(dataset1["cube"], size=11)
@@ -33,3 +30,17 @@ class testSCF(TestCase):
                          dataset2["cube"], size=11).distance_metric()
         npt.assert_almost_equal(self.tester_dist.distance,
                                 computed_distances['scf_distance'])
+
+    def test_SCF_regrid_distance(self):
+        hdr = dataset1["cube"][1].copy()
+        hdr["CDELT2"] = 0.5 * hdr["CDELT2"]
+        hdr["CDELT1"] = 0.5 * hdr["CDELT1"]
+        cube = zoom(dataset1["cube"][0], (1, 2, 2))
+
+        self.tester_dist_zoom = \
+            SCF_Distance([cube, hdr], dataset1["cube"],
+                         size=11).distance_metric(verbose=True)
+
+        fid_dist = 0.02
+
+        assert self.tester_dist_zoom < fid_dist


### PR DESCRIPTION
The indexing of the SCF surface was not updated to work with the non-integer shifts from #117.

Added tests for SCF for non-equal grids and non-integer shifts.

