### PR TITLE
NaN fourier shift

### DIFF
--- a/turbustat/statistics/scf/scf.py
+++ b/turbustat/statistics/scf/scf.py
@@ -86,8 +86,18 @@ class SCF(BaseStatisticMixIn):
 
         for i, x_shift in enumerate(dx):
             for j, y_shift in enumerate(dy):
-                tmp = fourier_shift(self.data, x_shift, axis=1)
-                tmp = fourier_shift(tmp, y_shift, axis=2)
+
+                if x_shift == 0 and y_shift == 0:
+                    self._scf_surface[i, j] = 1.
+
+                if x_shift == 0:
+                    tmp = self.data
+                else:
+                    tmp = fourier_shift(self.data, x_shift, axis=1)
+
+                if y_shift != 0:
+                    tmp = fourier_shift(tmp, y_shift, axis=2)
+
                 values = np.nansum(((self.data - tmp) ** 2), axis=0) / \
                     (np.nansum(self.data ** 2, axis=0) +
                      np.nansum(tmp ** 2, axis=0))

--- a/turbustat/statistics/stats_utils.py
+++ b/turbustat/statistics/stats_utils.py
@@ -162,7 +162,19 @@ def fourier_shift(x, shift, axis=0):
     x2 : np.ndarray
         Shifted array.
     '''
+    mask = ~np.isfinite(x)
+    nonan = x.copy()
+    nonan[mask] = 0.0
 
+    nonan_shift = _shifter(nonan, shift, axis)
+    mask_shift = _shifter(mask, shift, axis) > 0.5
+
+    nonan_shift[mask_shift] = np.NaN
+
+    return nonan_shift
+
+
+def _shifter(x, shift, axis):
     ftx = np.fft.fft(x, axis=axis)
     m = np.fft.fftfreq(x.shape[axis])
     m_shape = [1] * len(x.shape)


### PR DESCRIPTION
The Fourier shifting for SCF introduced in #117 fails with NaNs. This fixes that by shifting a NaN mask as well.