### PR TITLE
Plotting fixes to PDF and bispectrum

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #120 - Minor plotting changes to PDF and bispectrum. Common angular area for Genus normalization. Fix issue with NaNs in the weights for PDFs.
 * #118 - Fix SCF surface indexing with non-integer shifts.
 * #117 - Use common angular scales for SCF, Moments, Delta-Variance comparison. Dropped using nanmean, nanstd from scipy.stats. Added fourier shifting for SCF.
 * #116 - Normalize Genus distance by the image area for comparing unequally-sized images

--- a/turbustat/statistics/pdf/compare_pdf.py
+++ b/turbustat/statistics/pdf/compare_pdf.py
@@ -52,7 +52,9 @@ class PDF(BaseStatisticMixIn):
 
             self.weights = output_weights[keep_values]
 
-            self.data *= self.weights
+            isfinite = np.isfinite(self.weights)
+
+            self.data = self.data[isfinite] * self.weights[isfinite]
 
         self._standardize_flag = False
         if use_standardized:

--- a/turbustat/statistics/pdf/compare_pdf.py
+++ b/turbustat/statistics/pdf/compare_pdf.py
@@ -172,10 +172,10 @@ class PDF(BaseStatisticMixIn):
             if self._standardize_flag:
                 xlabel = r"z-score"
             else:
-                xlabel = r"$\Sigma$"
+                xlabel = r"Intensity"
 
             # PDF
-            p.subplot(131)
+            p.subplot(121)
             if self._standardize_flag:
                 p.plot(self.bins, self.pdf, 'b-')
             else:
@@ -185,27 +185,16 @@ class PDF(BaseStatisticMixIn):
             p.ylabel("PDF")
 
             # ECDF
-            p.subplot(132)
+            ax2 = p.subplot(122)
+            ax2.yaxis.tick_right()
+            ax2.yaxis.set_label_position("right")
             if self._standardize_flag:
-                p.plot(self.bins, self.ecdf, 'b-')
+                ax2.plot(self.bins, self.ecdf, 'b-')
             else:
-                p.semilogx(self.bins, self.ecdf, 'b-')
+                ax2.semilogx(self.bins, self.ecdf, 'b-')
             p.grid(True)
             p.xlabel(xlabel)
             p.ylabel("ECDF")
-
-            # Array representation.
-            p.subplot(133)
-            if self.img.ndim == 1:
-                p.plot(self.img, 'b-')
-            elif self.img.ndim == 2:
-                p.imshow(self.img, origin="lower", interpolation="nearest",
-                         cmap="binary")
-            elif self.img.ndim == 3:
-                p.imshow(np.nansum(self.img, axis=0), origin="lower",
-                         interpolation="nearest", cmap="binary")
-            else:
-                print("Visual representation works only up to 3D.")
 
             p.tight_layout()
             p.show()
@@ -240,13 +229,10 @@ class PDF_Distance(object):
                  weights1=None, weights2=None):
         super(PDF_Distance, self).__init__()
 
-        self.img1 = img1
-        self.img2 = img2
-
-        self.PDF1 = PDF(self.img1, min_val=min_val1, use_standardized=True,
+        self.PDF1 = PDF(img1, min_val=min_val1, use_standardized=True,
                         weights=weights1)
 
-        self.PDF2 = PDF(self.img2, min_val=min_val2, use_standardized=True,
+        self.PDF2 = PDF(img2, min_val=min_val2, use_standardized=True,
                         weights=weights2)
 
         self.bins, self.bin_centers = \
@@ -330,10 +316,7 @@ class PDF_Distance(object):
         if verbose:
             import matplotlib.pyplot as p
             # PDF
-            if show_data:
-                p.subplot(131)
-            else:
-                p.subplot(121)
+            p.subplot(121)
             p.plot(self.bin_centers,
                    self.PDF1.pdf, 'b-', label=label1)
             p.plot(self.bin_centers,
@@ -344,41 +327,14 @@ class PDF_Distance(object):
             p.ylabel("PDF")
 
             # ECDF
-            if show_data:
-                p.subplot(132)
-            else:
-                p.subplot(122)
-            p.plot(self.bin_centers, self.PDF1.ecdf, 'b-')
-            p.plot(self.bin_centers, self.PDF2.ecdf, 'g-')
+            ax2 = p.subplot(122)
+            ax2.yaxis.tick_right()
+            ax2.yaxis.set_label_position("right")
+            ax2.plot(self.bin_centers, self.PDF1.ecdf, 'b-')
+            ax2.plot(self.bin_centers, self.PDF2.ecdf, 'g-')
             p.grid(True)
             p.xlabel(r"z-score")
             p.ylabel("ECDF")
-
-            # Array representation.
-            if show_data:
-                p.subplot(233)
-                if self.img1.ndim == 1:
-                    p.plot(self.img1, 'b-')
-                elif self.img1.ndim == 2:
-                    p.imshow(self.img1, origin="lower",
-                             interpolation="nearest", cmap="binary")
-                elif self.img1.ndim == 3:
-                    p.imshow(np.nansum(self.img1, axis=0), origin="lower",
-                             interpolation="nearest", cmap="binary")
-                else:
-                    print("Visual representation works only up to 3D.")
-
-                p.subplot(236)
-                if self.img2.ndim == 1:
-                    p.plot(self.img2, 'b-')
-                elif self.img2.ndim == 2:
-                    p.imshow(self.img2, origin="lower",
-                             interpolation="nearest", cmap="binary")
-                elif self.img2.ndim == 3:
-                    p.imshow(np.nansum(self.img2, axis=0), origin="lower",
-                             interpolation="nearest", cmap="binary")
-                else:
-                    print("Visual representation works only up to 3D.")
 
             p.show()
 

--- a/turbustat/statistics/pspec_bispec/pspec_bispec.py
+++ b/turbustat/statistics/pspec_bispec/pspec_bispec.py
@@ -380,7 +380,8 @@ class BiSpectrum_Distance(object):
         if verbose:
             import matplotlib.pyplot as p
 
-            ax1 = p.subplot(221)
+            fig = p.figure()
+            ax1 = fig.add_subplot(121)
             ax1.set_title(label1)
             ax1.imshow(
                 self.bispec1.bicoherence, origin="lower",
@@ -388,26 +389,20 @@ class BiSpectrum_Distance(object):
             ax1.set_xlabel(r"$k_1$")
             ax1.set_ylabel(r"$k_2$")
 
-            ax2 = p.subplot(223)
+            ax2 = fig.add_subplot(122)
             ax2.set_title(label2)
-            ax2.imshow(
+            im = p.imshow(
                 self.bispec2.bicoherence, origin="lower",
                 interpolation="nearest", vmax=1.0, vmin=0.0)
             ax2.set_xlabel(r"$k_1$")
-            ax2.set_ylabel(r"$k_2$")
+            # ax2.set_ylabel(r"$k_2$")
+            ax2.set_yticklabels([])
 
-            ax3 = p.subplot(122)
-            ax3.set_title("Difference")
-            p.imshow(np.abs(self.bispec1.bicoherence -
-                            self.bispec2.bicoherence),
-                     origin="lower", interpolation="nearest",
-                     vmax=1.0, vmin=0.0)
-            cbar = p.colorbar(ax=ax3)
-            ax3.set_xlabel(r"$k_1$")
-            ax3.set_ylabel(r"$k_2$")
+            fig.subplots_adjust(right=0.8)
+            cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])
+            fig.colorbar(im, cax=cbar_ax)
 
-            p.tight_layout()
-
+            # p.tight_layout()
             p.show()
 
         return self


### PR DESCRIPTION
Fixes errors when creating plots for PDF and bispectrum with data of different shapes.

Also added a common angular scale factor correction to the Genus distance normalization. Normalization is now effectively over a common angular area.