### PR TITLE
Fix indexing for azimuthal averaging

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #133 - Fix indexing when creating 1D power spectra.
 * #131 - Another correction for centroid offset issue. Cleaned moment calcs up a bit.
 * #130 - Corrections to moment error calculations.
 * #128 - log-log plotting for SCF spectrum. Fitting for SCF spectrum.

--- a/turbustat/statistics/psds.py
+++ b/turbustat/statistics/psds.py
@@ -45,7 +45,7 @@ def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
     x = np.arange(-np.floor(psd2.shape[1]/2.).astype(int),
                   psd2.shape[1] - np.floor(psd2.shape[1]/2.).astype(int))
 
-    yy, xx = np.meshgrid(y, x)
+    yy, xx = np.meshgrid(y, x, indexing='ij')
 
     dists = np.sqrt(yy**2 + xx**2)
 
@@ -56,7 +56,7 @@ def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
         yfreqs = np.fft.fftshift(np.abs(np.fft.fftfreq(psd2.shape[0])))
         xfreqs = np.fft.fftshift(np.abs(np.fft.fftfreq(psd2.shape[1])))
 
-        yy_freq, xx_freq = np.meshgrid(yfreqs, xfreqs)
+        yy_freq, xx_freq = np.meshgrid(yfreqs, xfreqs, indexing='ij')
 
         freqs_dist = np.sqrt(yy_freq**2 + xx_freq**2)
 

--- a/turbustat/statistics/psds.py
+++ b/turbustat/statistics/psds.py
@@ -40,17 +40,17 @@ def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
         within each of the bins.
     '''
 
-    y = np.arange(-np.floor(psd2.shape[0]/2.).astype(int),
-                  psd2.shape[0] - np.floor(psd2.shape[0]/2.).astype(int))
-    x = np.arange(-np.floor(psd2.shape[1]/2.).astype(int),
-                  psd2.shape[1] - np.floor(psd2.shape[1]/2.).astype(int))
+    y = np.arange(-np.floor(psd2.shape[0] / 2.).astype(int),
+                  psd2.shape[0] - np.floor(psd2.shape[0] / 2.).astype(int))
+    x = np.arange(-np.floor(psd2.shape[1] / 2.).astype(int),
+                  psd2.shape[1] - np.floor(psd2.shape[1] / 2.).astype(int))
 
     yy, xx = np.meshgrid(y, x, indexing='ij')
 
     dists = np.sqrt(yy**2 + xx**2)
 
     if nbins is None:
-        nbins = int(np.round(dists.max() / binsize)+1)
+        nbins = int(np.round(dists.max() / binsize) + 1)
 
     if return_freqs:
         yfreqs = np.fft.fftshift(np.abs(np.fft.fftfreq(psd2.shape[0])))
@@ -76,9 +76,9 @@ def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
             min_bin = 0.5
 
     if logspacing:
-        bins = np.logspace(np.log10(min_bin), np.log10(max_bin), nbins+1)
+        bins = np.logspace(np.log10(min_bin), np.log10(max_bin), nbins + 1)
     else:
-        bins = np.linspace(min_bin, max_bin, nbins+1)
+        bins = np.linspace(min_bin, max_bin, nbins + 1)
 
     if return_freqs:
         dist_arr = freqs_dist

--- a/turbustat/tests/test_pspec.py
+++ b/turbustat/tests/test_pspec.py
@@ -38,3 +38,14 @@ class testPSpec(TestCase):
 
         npt.assert_almost_equal(self.tester_dist.distance,
                                 computed_distances['pspec_distance'])
+
+
+def test_pspec_nonequal_shape():
+
+    mom0_sliced = dataset1["moment0"][0][:16, :]
+    mom0_hdr = dataset1["moment0"][1]
+
+    test = PowerSpectrum((mom0_sliced, mom0_hdr)).run()
+    test_T = PowerSpectrum((mom0_sliced.T, mom0_hdr)).run()
+
+    npt.assert_almost_equal(test.slope, test_T.slope, decimal=7)


### PR DESCRIPTION
The indexing in `turbustat.statistics.psds.pspec` was swapped, creating issues whenever the 2D array did not have an equal shape.