### PR TITLE
Cramer normalization

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #136 - Normalize data to between 0 and 1 for the Cramer statistic.
 * #134 - Add rolling back for computing the SCF when shifts are integers (and so don't need the FFT approach)
 * #133 - Fix indexing when creating 1D power spectra.
 * #131 - Another correction for centroid offset issue. Cleaned moment calcs up a bit.

--- a/turbustat/statistics/cramer/cramer.py
+++ b/turbustat/statistics/cramer/cramer.py
@@ -51,15 +51,34 @@ class Cramer_Distance(object):
         self.data_matrix2 = None
         self.distance = None
 
-    def format_data(self, data_format='intensity', seed=13024):
+    def format_data(self, data_format='intensity', seed=13024, normalize=True,
+                    **kwargs):
         '''
         Rearrange data into a 2D object using the given format.
+
+        Parameters
+        ----------
+        data_format : {'intensity', 'spectra'}, optional
+            The method to use to construct the data matrix. The default is
+            intensity, which picks the brightest values in each channel. The
+            other option is 'spectra', which will pick the N brightest spectra
+            to compare.
+        seed : int, optional
+            When the data are mismatched, the larger data set is randomly
+            sampled to match the size of the other.
+        normalize : bool, optional
+            Forces the data sets into the same interval, removing the
+            effect of different ranges of intensities (or whatever unit the
+            data traces).
+        kwargs : Passed to `~turbustat.statistics.threeD_to_twoD._format_data`.
         '''
 
         self.data_matrix1 = _format_data(self.cube1, data_format=data_format,
-                                         noise_lim=self.noise_value1)
+                                         noise_lim=self.noise_value1,
+                                         normalize=normalize, **kwargs)
         self.data_matrix2 = _format_data(self.cube2, data_format=data_format,
-                                         noise_lim=self.noise_value2)
+                                         noise_lim=self.noise_value2,
+                                         normalize=normalize, **kwargs)
 
         # Need to check if the same number of samples is taken
         samps1 = self.data_matrix1.shape[1]
@@ -101,7 +120,7 @@ class Cramer_Distance(object):
 
         n_jobs : int, optional
             Sets the number of cores to use to calculate
-            pairwise distances
+            pairwise distances. Default is 1.
         '''
         # Adjust what we call n,m based on the larger dimension.
         # Then the looping below is valid.
@@ -145,15 +164,22 @@ class Cramer_Distance(object):
 
         self.distance = (m * n / (m + n)) * (term1 - term2 - term3)
 
-    def distance_metric(self, n_jobs=1):
+    def distance_metric(self, normalize=True, n_jobs=1):
         '''
 
         This serves as a simple wrapper in order to remain with the coding
         convention used throughout the rest of this project.
 
+        Parameters
+        ----------
+        normalize : bool, optional
+            See `Cramer_Distance.format_data`.
+
+        n_jobs : int, optional
+            See `Cramer_Distance.cramer_statistic`.
         '''
 
-        self.format_data()
+        self.format_data(normalize=normalize)
         self.cramer_statistic(n_jobs=n_jobs)
 
         return self

--- a/turbustat/statistics/cramer/cramer.py
+++ b/turbustat/statistics/cramer/cramer.py
@@ -38,8 +38,8 @@ class Cramer_Distance(object):
 
     __doc__ %= {"dtypes": " or ".join(common_types + threed_types)}
 
-    def __init__(self, cube1, cube2, noise_value1=0.1,
-                 noise_value2=0.1):
+    def __init__(self, cube1, cube2, noise_value1=-np.inf,
+                 noise_value2=-np.inf):
         super(Cramer_Distance, self).__init__()
         self.cube1 = input_data(cube1, no_header=True)
         self.cube2 = input_data(cube2, no_header=True)

--- a/turbustat/statistics/threeD_to_twoD.py
+++ b/turbustat/statistics/threeD_to_twoD.py
@@ -61,7 +61,7 @@ def intensity_data(cube, p=0.1, noise_lim=0.1, norm=True):
 
 
 def _format_data(cube, data_format='intensity', num_spec=1000,
-                 noise_lim=0.0, p=0.1):
+                 noise_lim=0.0, p=0.1, normalize=True):
     '''
     Rearrange data into a 2D object using the given format.
     '''
@@ -93,6 +93,14 @@ def _format_data(cube, data_format='intensity', num_spec=1000,
     else:
         raise NameError(
             "data_format must be either 'spectra' or 'intensity'.")
+
+    # Normalize by rescaling the data to an interval between 0 and 1
+    # Ignore all values of 0, since they're just filled in.
+    if normalize:
+        nonzero = np.nonzero(data_matrix)
+        ptp = np.ptp(data_matrix[nonzero])
+        data_matrix[nonzero] = \
+            (data_matrix[nonzero] - data_matrix[nonzero].min()) / ptp
 
     return data_matrix
 

--- a/turbustat/statistics/wrapping_function.py
+++ b/turbustat/statistics/wrapping_function.py
@@ -4,6 +4,8 @@ Wrapper to run all of the statistics between two data sets.
 For large-scale comparisons, this is the function that should be called.
 '''
 
+import numpy as np
+
 from .wavelets import Wavelet_Distance
 from .mvc import MVC_Distance
 from .pspec_bispec import PSpec_Distance, BiSpectrum_Distance
@@ -24,6 +26,7 @@ from statistics_list import statistics_list
 def stats_wrapper(dataset1, dataset2, fiducial_models=None,
                   statistics=None, multicore=False, vca_break=None,
                   vcs_break=None, dendro_params=None,
+                  noise_value=[-np.inf, -np.inf],
                   dendro_saves=[None, None],
                   cleanup=True):
     '''
@@ -206,7 +209,9 @@ def stats_wrapper(dataset1, dataset2, fiducial_models=None,
         if any("Cramer" in s for s in statistics):
             cramer_distance = \
                 Cramer_Distance(dataset1["cube"],
-                                dataset2["cube"]).distance_metric()
+                                dataset2["cube"],
+                                noise_value1=noise_value[0],
+                                noise_value2=noise_value[1]).distance_metric()
             distances["Cramer"] = cramer_distance.distance
 
             if cleanup:
@@ -406,7 +411,9 @@ def stats_wrapper(dataset1, dataset2, fiducial_models=None,
         if any("Cramer" in s for s in statistics):
             cramer_distance = \
                 Cramer_Distance(dataset1["cube"],
-                                dataset2["cube"]).distance_metric()
+                                dataset2["cube"],
+                                noise_value1=noise_value[0],
+                                noise_value2=noise_value[1]).distance_metric()
             distances["Cramer"] = cramer_distance.distance
 
             if cleanup:

--- a/turbustat/tests/data/GetVals.py
+++ b/turbustat/tests/data/GetVals.py
@@ -176,7 +176,9 @@ scf_val_noncon_bound = scf_distance_cut_bound.scf1.scf_surface
 from turbustat.statistics import Cramer_Distance
 
 cramer_distance = Cramer_Distance(dataset1["cube"],
-                                  dataset2["cube"]).distance_metric(normalize=False)
+                                  dataset2["cube"],
+                                  noise_value1=0.1,
+                                  noise_value2=0.1).distance_metric(normalize=False)
 
 cramer_val = cramer_distance.data_matrix1
 

--- a/turbustat/tests/data/GetVals.py
+++ b/turbustat/tests/data/GetVals.py
@@ -176,7 +176,7 @@ scf_val_noncon_bound = scf_distance_cut_bound.scf1.scf_surface
 from turbustat.statistics import Cramer_Distance
 
 cramer_distance = Cramer_Distance(dataset1["cube"],
-                                  dataset2["cube"]).distance_metric()
+                                  dataset2["cube"]).distance_metric(normalize=False)
 
 cramer_val = cramer_distance.data_matrix1
 

--- a/turbustat/tests/test_cramer.py
+++ b/turbustat/tests/test_cramer.py
@@ -18,8 +18,11 @@ from ._testing_data import \
 class testCramer(TestCase):
 
     def test_cramer(self):
-        self.tester = Cramer_Distance(dataset1["cube"],
-                                      dataset2["cube"]).distance_metric(normalize=False)
+        self.tester = \
+            Cramer_Distance(dataset1["cube"],
+                            dataset2["cube"],
+                            noise_value1=0.1,
+                            noise_value2=0.1).distance_metric(normalize=False)
 
         npt.assert_allclose(self.tester.data_matrix1,
                             computed_data["cramer_val"])

--- a/turbustat/tests/test_cramer.py
+++ b/turbustat/tests/test_cramer.py
@@ -19,7 +19,7 @@ class testCramer(TestCase):
 
     def test_cramer(self):
         self.tester = Cramer_Distance(dataset1["cube"],
-                                      dataset2["cube"]).distance_metric()
+                                      dataset2["cube"]).distance_metric(normalize=False)
 
         npt.assert_allclose(self.tester.data_matrix1,
                             computed_data["cramer_val"])
@@ -31,8 +31,8 @@ class testCramer(TestCase):
         small_data = dataset1["cube"][0][:, :26, :26]
 
         self.tester2 = Cramer_Distance(small_data, dataset2["cube"])
-        self.tester2.distance_metric()
+        self.tester2.distance_metric(normalize=False)
         self.tester3 = Cramer_Distance(dataset2["cube"], small_data)
-        self.tester3.distance_metric()
+        self.tester3.distance_metric(normalize=False)
 
         npt.assert_almost_equal(self.tester2.distance, self.tester3.distance)


### PR DESCRIPTION
Added a normalization factor when computing the Cramer. The data matrices to calculate the statistics are now normalized by default to be within a range of 0 to 1. This ensures that constant offsets do not inflate the distance.