### PR TITLE
Periodic dendrogram boundaries

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #143 - Set periodic boundaries for dendrograms.
 * #141 - Added fitting for delta-variance. Added setting of fit limits for delta-variance, wavelets, power spectrum, MVC, and VCA.
 * #138 - Add fitting routines and more normalization options for PDFs. Added testing for numpy 1.12 and astropy 1.3.
 * #136 - Normalize data to between 0 and 1 for the Cramer statistic.

--- a/turbustat/statistics/dendrograms/dendro_stats.py
+++ b/turbustat/statistics/dendrograms/dendro_stats.py
@@ -19,7 +19,7 @@ import statsmodels.api as sm
 from mecdf import mecdf
 
 try:
-    from astrodendro import Dendrogram
+    from astrodendro import Dendrogram, periodic_neighbours
     astrodendro_flag = True
 except ImportError:
     Warning("Need to install astrodendro to use dendrogram statistics.")
@@ -27,7 +27,7 @@ except ImportError:
 
 from ..stats_utils import hellinger, common_histogram_bins, standardize
 from ..base_statistic import BaseStatisticMixIn
-from ...io import common_types, threed_types, twod_types, input_data
+from ...io import common_types, threed_types, twod_types
 
 
 class Dendrogram_Stats(BaseStatisticMixIn):
@@ -54,17 +54,14 @@ class Dendrogram_Stats(BaseStatisticMixIn):
     __doc__ %= {"dtypes": " or ".join(common_types + twod_types +
                                       threed_types)}
 
-    def __init__(self, data, min_deltas=None, dendro_params=None):
+    def __init__(self, data, header=None, min_deltas=None, dendro_params=None):
         super(Dendrogram_Stats, self).__init__()
 
         if not astrodendro_flag:
             raise ImportError("astrodendro must be installed to use "
                               "Dendrogram_Stats.")
 
-        # A header isn't needed. Disable the check flag
-        self.need_header_flag = False
-        self.header = None
-        self.data = input_data(data, no_header=True)
+        self.input_data_header(data, header)
 
         if dendro_params is None:
             self.dendro_params = {"min_npix": 10,
@@ -89,7 +86,8 @@ class Dendrogram_Stats(BaseStatisticMixIn):
         self.histograms = []
 
     def compute_dendro(self, verbose=False, save_dendro=False,
-                       dendro_name=None, dendro_obj=None):
+                       dendro_name=None, dendro_obj=None,
+                       periodic_bounds=False):
         '''
         Compute the dendrogram and prune to the minimum deltas.
         ** min_deltas must be in ascending order! **
@@ -106,15 +104,27 @@ class Dendrogram_Stats(BaseStatisticMixIn):
         dendro_obj : Dendrogram, optional
             Input a pre-computed dendrogram object. It is assumed that
             the dendrogram has already been computed!
-
+        periodic_bounds : bool, optional
+            Enable when the data is periodic in the spatial dimensions.
         '''
 
         if dendro_obj is None:
-            d = \
-                Dendrogram.compute(self.data, verbose=verbose,
+            if periodic_bounds:
+                # Find the spatial dimensions
+                num_axes = self.data.ndim
+                spat_axes = []
+                for i, axis_type in enumerate(self._wcs.get_axis_types()):
+                    if axis_type["coordinate_type"] == u"celestial":
+                        spat_axes.append(num_axes - i - 1)
+                neighbours = periodic_neighbours(spat_axes)
+            else:
+                neighbours = None
+
+            d = Dendrogram.compute(self.data, verbose=verbose,
                                    min_delta=self.min_deltas[0],
                                    min_value=self.dendro_params["min_value"],
-                                   min_npix=self.dendro_params["min_npix"])
+                                   min_npix=self.dendro_params["min_npix"],
+                                   neighbours=neighbours)
         else:
             d = dendro_obj
         self.numfeatures[0] = len(d)
@@ -254,8 +264,9 @@ class Dendrogram_Stats(BaseStatisticMixIn):
 
         return self
 
-    def run(self, verbose=False, dendro_verbose=False,
-            save_results=False, output_name=None):
+    def run(self, periodic_bounds=False, verbose=False,
+            dendro_verbose=False, save_results=False,
+            output_name=None):
         '''
 
         Compute dendrograms. Necessary to maintain the package format.
@@ -263,11 +274,12 @@ class Dendrogram_Stats(BaseStatisticMixIn):
         Parameters
         ----------
         verbose : optional, bool
-
+            Plots the number of objects in the tree as a function of delta.
         dendro_verbose : optional, bool
             Prints out updates while making the dendrogram.
         '''
-        self.compute_dendro(verbose=dendro_verbose)
+        self.compute_dendro(verbose=dendro_verbose,
+                            periodic_bounds=periodic_bounds)
         self.fit_numfeat(verbose=verbose)
 
         if verbose:
@@ -317,14 +329,18 @@ class DendroDistance(object):
         (see www.dendrograms.org for more info). If a list of dictionaries is
         given, the first list entry should be the dictionary for cube1, and the
         second for cube2.
-
+    periodic_bounds : bool or list, optional
+        Enable when the data is periodic in the spatial dimensions. Passing
+        a two-element list can be used to individually set how the boundaries
+        are treated for the datasets.
     """
 
     __doc__ %= {"dtypes": " or ".join(common_types + twod_types +
                                       threed_types)}
 
     def __init__(self, cube1, cube2, min_deltas=None, nbins="best",
-                 min_features=100, fiducial_model=None, dendro_params=None):
+                 min_features=100, fiducial_model=None, dendro_params=None,
+                 periodic_bounds=False):
         super(DendroDistance, self).__init__()
 
         if not astrodendro_flag:
@@ -353,6 +369,13 @@ class DendroDistance(object):
             dendro_params1 = None
             dendro_params2 = None
 
+        if isinstance(periodic_bounds, bool):
+            periodic_bounds = [periodic_bounds] * 2
+        else:
+            if not len(periodic_bounds) == 2:
+                raise ValueError("periodic_bounds should be a two-element"
+                                 " list.")
+
         if fiducial_model is not None:
             self.dendro1 = fiducial_model
         elif isinstance(cube1, str):
@@ -360,7 +383,7 @@ class DendroDistance(object):
         else:
             self.dendro1 = Dendrogram_Stats(
                 cube1, min_deltas=min_deltas, dendro_params=dendro_params1)
-            self.dendro1.run(verbose=False)
+            self.dendro1.run(verbose=False, periodic_bounds=periodic_bounds[0])
 
         if isinstance(cube2, str):
             self.dendro2 = Dendrogram_Stats.load_results(cube2)
@@ -368,7 +391,7 @@ class DendroDistance(object):
             self.dendro2 = \
                 Dendrogram_Stats(cube2, min_deltas=min_deltas,
                                  dendro_params=dendro_params2)
-            self.dendro2.run(verbose=False)
+            self.dendro2.run(verbose=False, periodic_bounds=periodic_bounds[1])
 
         # Set the minimum number of components to create a histogram
         cutoff1 = np.argwhere(self.dendro1.numfeatures > min_features)

--- a/turbustat/tests/test_dendro.py
+++ b/turbustat/tests/test_dendro.py
@@ -5,8 +5,6 @@
 Tests for Dendrogram statistics
 '''
 
-from unittest import TestCase
-
 import numpy as np
 import numpy.testing as npt
 
@@ -15,28 +13,28 @@ from ._testing_data import \
     dataset1, dataset2, computed_data, computed_distances
 
 
-class testDendrograms(TestCase):
+min_deltas = np.logspace(-1.5, 0.5, 40)
 
-    def setUp(self):
-        self.min_deltas = np.logspace(-1.5, 0.5, 40)
 
-    def test_DendroStat(self):
+def test_DendroStat():
 
-        self.tester = Dendrogram_Stats(dataset1["cube"],
-                                       min_deltas=self.min_deltas)
-        self.tester.run()
+    tester = Dendrogram_Stats(dataset1["cube"],
+                              min_deltas=min_deltas)
+    tester.run(periodic_bounds=False)
 
-        npt.assert_allclose(self.tester.numfeatures,
-                            computed_data["dendrogram_val"])
+    npt.assert_allclose(tester.numfeatures,
+                        computed_data["dendrogram_val"])
 
-    def test_DendroDistance(self):
 
-        self.tester_dist = \
-            DendroDistance(dataset1["cube"],
-                           dataset2["cube"],
-                           min_deltas=self.min_deltas).distance_metric()
+def test_DendroDistance():
 
-        npt.assert_almost_equal(self.tester_dist.histogram_distance,
-                                computed_distances["dendrohist_distance"])
-        npt.assert_almost_equal(self.tester_dist.num_distance,
-                                computed_distances["dendronum_distance"])
+    tester_dist = \
+        DendroDistance(dataset1["cube"],
+                       dataset2["cube"],
+                       min_deltas=min_deltas,
+                       periodic_bounds=False).distance_metric()
+
+    npt.assert_almost_equal(tester_dist.histogram_distance,
+                            computed_distances["dendrohist_distance"])
+    npt.assert_almost_equal(tester_dist.num_distance,
+                            computed_distances["dendronum_distance"])


### PR DESCRIPTION
Enables toggling whether the spatial dimensions of a cube/map are periodic.

By default, periodic boundaries are disabled.

In order to determine which axes are spatial dimensions, a FITS header is now required for `Dendrogram_Stats`.