### PR TITLE
[WIP] Full VCS modelling

### DIFF
--- a/turbustat/statistics/vca_vcs/vcs_model_helpers.pyx
+++ b/turbustat/statistics/vca_vcs/vcs_model_helpers.pyx
@@ -1,0 +1,301 @@
+
+import numpy as np
+from scipy.integrate import quad
+from scipy.special import gamma, erf, erfc
+cimport cython
+
+from libc.math cimport sqrt, exp, sin, cos, atan
+
+cdef double pi = np.pi
+
+
+def C_eps(double r, double k_cut, double alphae, double norm_factor):
+    '''
+
+    k_cut is k0 for alphae > 3 and k1 for alphae<3
+    '''
+
+    cdef double Int
+
+    # Steep
+    if alphae > 3:
+        # Eq. B2
+        Int = Int3(r, k_cut, alphae)[0]
+
+        return 1 - 4 * pi * Int / norm_factor
+    elif alphae == 3:
+        # No density dependence.
+        return 1. / norm_factor
+    # Shallow
+    elif alphae > 1:
+        # For alphae between 1 and 3
+
+        Int = Int4(r, k_cut, alphae)[0]
+
+        return 1 - 4 * pi * Int / norm_factor
+
+    else:
+        raise ValueError("Solution not defined for alphae <= 1.")
+
+
+def Dz(double r, double theta, double V0, double k0, double alphav):
+    '''
+    Eq. A3 to A5.
+
+    I've only included the solutions for a solenoidal velocity
+    field here. The solution for a potential field is defined in Eqs. A8 & A9
+    and can be easily included here. Do they need to be?
+    '''
+
+    cdef double intone, inttwo, I_C, I_S
+
+    intone = Int1(r, k0, alphav)[0]
+    inttwo = Int2(r, k0, alphav)[0]
+
+    I_C = (4 / 3.) * intone
+    I_S = 2 * (inttwo - intone / 3.)
+
+    return 4 * pi * V0**2 * r**(alphav - 3) * \
+        (I_C * cos(theta)**2 + I_S * sin(theta)**2)
+
+
+def F_eps_norm(double alphae, double k_cut):
+    '''
+    Normalization for F_eps.
+
+    If alphae > 3, k_cut is k0 (Eq. B1). If alphae < 3, k_cut is k1 (Eq. B5).
+
+    '''
+
+    cdef double prefactor
+
+    prefactor = 2 * pi * k_cut**(3 - alphae)
+
+    if alphae > 3:
+        return prefactor * gamma(0.5 * (alphae - 3))
+    elif alphae < 3:
+        return prefactor * gamma(0.5 * (3 - alphae))
+    else:
+        # If alphae == 3, the density spectrum has no contribution
+        return 1.
+
+# Integrals in Dz and C_eps
+
+def Int1(double r, double k0, double alphav):
+    '''
+    Integral in Eq. A4
+    '''
+    def integrand(double q):
+        cdef double out
+        out = q**(2 - alphav) * exp(-(k0 * r / q)**2) * \
+            (1 - (3 / q**2) * (sin(q) / q - cos(q)))
+        return out
+
+    cdef double value, err
+
+    value, err = quad(integrand, 0, np.inf)
+
+    return value, err
+
+
+def Int2(double r, double k0, double alphav):
+    '''
+    First integral in Eq. A5
+    '''
+
+    def integrand(double q):
+        cdef double out
+        out = q**(2 - alphav) * exp(-(k0 * r / q)**2) * \
+            (1 - sin(q) / q)
+        return out
+
+    cdef double value, err
+
+    value, err = quad(integrand, 0, np.inf)
+
+    return value, err
+
+
+def Int3(double r, double k0, double alphae):
+    '''
+    Eq. B2 (w/o 4pi constant)
+    '''
+
+    def integrand(double k):
+        cdef double out
+        out = k**(1 - alphae) * exp(-(k0 / k)**2) * \
+            (sin(k * r) / r)
+        return out
+
+    cdef double value, err
+
+    value, err = quad(integrand, 0, np.inf)
+
+    return value, err
+
+
+def Int4(double r, double k1, double alphae):
+    '''
+    Eq. B7
+    '''
+
+    def integrand(double q):
+        cdef double out
+        out = q**(1 - alphae) * exp(-(q / (k1 * r))**2) * sin(q)
+        return out
+
+    cdef double value, err
+
+    value, err = quad(integrand, 0, np.inf)
+
+    return value, err
+
+
+# Window functions
+
+def gaussian_beam(double theta, double theta_0):
+    '''
+    Normalized Gaussian
+
+    Note that Eq. 33 and 34 in CL06 are missing the sqrt in the normalization.
+    '''
+    cdef double out
+    out = exp(-(theta / theta_0)**2) / sqrt(pi * theta_0**2)
+    return out
+
+
+def gaussian_autocorr(double R, double z_0, double theta_0):
+    '''
+    Gaussian autocorrelation function for a circular Gaussian beam defined
+    in the projected frame (:math:`\vec{R}` in CL06). This is the solution for
+    Eq. 32.
+
+    For W_b:
+    :math:`-\frac{e^{-\frac{R^2}{2 \theta ^2 z^2}} \left(\sqrt{\pi } R e^{\frac{R^2}{4 \theta ^2 z^2}} \text{erfc}\left(\frac{R}{2 \theta  z}\right)-2 \theta  z\right)}{4 \theta  z^3}`
+
+    w_b was solved for using Mathematica. My by-hand solution had the same
+    asymptotic behaviour, but looked so much worse than the compacter form
+    above.
+
+    '''
+
+    cdef double ratio_term, exp_term
+
+    ratio_term = R / (theta_0 * z_0)
+    exp_term = ratio_term**2
+
+    term1 = - 1. / (4 * theta_0 * z_0**3)
+    term2 = sqrt(pi) * R * exp(- 0.25 * exp_term) * \
+        erfc(0.5 * ratio_term)
+    term3 = 2 * theta_0 * z_0 * exp(- 0.5 * exp_term)
+
+    return term1 * (term2 - term3)
+
+
+def slab_autocorr(double z, double z_0, double z_1):
+    '''
+    Slab model. The function is 1 for z within z_0 and z_1. See Eq. 40.
+    This is a normalized version, so the values are 1 / (z_1 - z_0).
+
+    The autocorrelation function is just the square, so
+    :math:`(z_1 - z_0)^{-2}`.
+
+    '''
+
+    cdef double out
+
+    if z >= z_0 and z <= z_1:
+        out = (z_1 - z_0)**2
+        return out
+
+
+def pencil_beam_gaussian_z(double z, double sigma_z):
+    '''
+    Pencil beam with a Gaussian w_eps_a.
+    '''
+
+    return gaussian_beam(z, 2 * sigma_z)
+
+
+def pencil_beam_slab_z(double z, double z0, double z1):
+    '''
+    Pencil beam with a slab w_eps_a.
+    '''
+
+    return slab_autocorr(z, z0, z1)
+
+
+def gaussian_beam_slab_z_crossing(double R, double z, double z0, double z1,
+                                  double theta0):
+    '''
+    Eq. 41 -- Gaussian beam with w_eps as tophat between z0 and z1.
+
+    Same as Eq.14 in Chepurnov+10 (called g(r) there).
+
+    Appropriate for limited resolution with nearby emission.
+
+    '''
+
+    cdef double term1, p, term_a, term_b, term2, term3, term4
+
+    term1 = - 1 / (2 * pi**0.5 * theta0 * R * z)
+
+    p = (z1 + z0) / (z1 - z0)
+
+    term_a = sqrt(2 * z0**2 + p * z**2)
+    term_b = sqrt(2 * z1**2 - p * z**2)
+
+    term2 = atan(1 + 2 * z0 / z) + atan(1 - 2 * z1 / z)
+    term3 = 1 / term_a - 1 / term_b
+
+    term4 = erf(R / (theta0 * term_a) - erf(R / (theta0 * term_b)))
+
+    return term1 * (term2 / term3) * term4
+
+
+def gaussian_beam_slab_z_parallel(double R, double z, double z0, double z1,
+                                  double theta0):
+    '''
+    Gaussian beam with w_eps_a as a slab (or tophat) with parallel LOS.
+
+    B/c this is in the parallel limit, the two component for the beam and
+    the structure along the LOS are independent. This allows us to easily
+    write out the components without needing to solve for the special case,
+    as was done for gaussian_beam_slab_z_crossing.
+
+    '''
+
+    return slab_autocorr(z, z0, z1) * gaussian_autocorr(R, z0, theta0)
+
+
+def gaussian_beam_gaussian_z_parallel(double R, double z, double z_0,
+                                      double sigma_z, double theta0):
+    '''
+    Solution to Eq. 31 assuming a Gaussian beam and a Gaussian for w_eps.
+
+    * Gaussian beam has width theta0 (not FWHM, 2 sigma)
+    * Gaussian for structure along LOS at a distance of z0 and a width of
+      sigma_z
+
+    The auto-correlation function is presented for both of these.
+
+    For w_eps:
+    :math:`e^{-z^2 / 4\sigma_z^2} / \sqrt{4 \pi \sigma_z^2}`
+
+    This is independent of z_0 as it is the distance to the object for this
+    definition. The autocorrelation function is for the object thickness along
+    the LOS, and so should be independent of distance.
+
+    For W_b:
+    :math:`-\frac{e^{-\frac{R^2}{2 \theta ^2 z^2}} \left(\sqrt{\pi } R e^{\frac{R^2}{4 \theta ^2 z^2}} \text{erfc}\left(\frac{R}{2 \theta  z}\right)-2 \theta  z\right)}{4 \theta  z^3}`
+
+    '''
+
+    cdef double w_eps_a, w_b_a
+
+    # See form above. Equal to 2 * sigma_z for "theta_0"
+    w_eps_a = gaussian_beam(z, 2 * sigma_z)
+
+    w_b_a = gaussian_autocorr(R, z_0, theta0)
+
+    return w_eps_a * w_b_a

--- a/turbustat/statistics/vca_vcs/vcs_models.py
+++ b/turbustat/statistics/vca_vcs/vcs_models.py
@@ -1,0 +1,167 @@
+
+import numpy as np
+from scipy.integrate import tplquad
+from astropy import constants as const
+import astropy.units as u
+from functools import partial
+import math
+
+try:
+    import vegas
+    VEGAS_IMPORT_FLAG = True
+except ImportError:
+    VEGAS_IMPORT_FLAG = False
+
+
+from vcs_model_helpers import (Dz, C_eps, F_eps_norm, pencil_beam_slab_z,
+                               pencil_beam_gaussian_z,
+                               gaussian_beam_slab_z_parallel,
+                               gaussian_beam_slab_z_crossing,
+                               gaussian_beam_gaussian_z_parallel)
+
+
+def P1(kv, alphav, alphae, P0, k0, V0, T, b=0,
+       beam_type='gaussian', object_type='gaussian', los_type='parallel',
+       z0=None, z1=None, sigma_z=None, theta0=None, k1=None,
+       integration_type='mc', **integration_kwargs):
+    '''
+    VCS model.
+    '''
+
+    fk2 = f_k(kv, T)**2
+
+    window = partial(window_function, beam_type=beam_type,
+                     object_type=object_type, los_type=los_type,
+                     sigma_z=sigma_z, z0=z0, z1=z1, theta0=theta0)
+
+    # Set bounds based on the inputs
+    if object_type == "gaussian":
+        z_bounds = [z0 - 5 * sigma_z, z0 + 5 * sigma_z]
+    else:
+        # Only consider values within the slab
+        z_bounds = [z0, z1]
+
+    if beam_type == "gaussian":
+        # becomes highly attenuated near the beam size
+        r_bounds = [0, 1.5 * theta0 * z0]
+    else:
+        # Pencil beam
+        raise NotImplementedError("A reasonable bound for R still needs to be"
+                                  " implemented!")
+        r_bounds = [0, ]
+
+    if alphae == 3:
+
+        def integrand(z, theta, r):
+
+            # Extra factor of r on each for the cylindrical Jacobian
+            # No density contribution
+            return window(r, z) * \
+                math.exp(-0.5 * kv**2 * Dz(r, theta, V0, k0, alphav))  # -
+                       # 1.0j * kv * b * z) * r
+
+    elif alphae > 3:
+
+        norm_factor = F_eps_norm(alphae, k0)
+
+        def integrand(z, theta, r):
+
+            # Extra factor of r on each for the cylindrical Jacobian
+            # Steep density
+            return window(r, z) * \
+                C_eps(r, k0, alphae, norm_factor) * \
+                math.exp(-0.5 * kv**2 * Dz(r, theta, V0, k0, alphav))  # -
+                       # 1.0j * kv * b * z) * r
+    else:
+
+        norm_factor = F_eps_norm(alphae, k1)
+
+        def integrand(z, theta, r):
+
+            # Extra factor of r on each for the cylindrical Jacobian
+            # Shallow density
+            return window(r, z) * \
+                C_eps(r, k1, alphae, norm_factor) * \
+                math.exp(-0.5 * kv**2 * Dz(r, theta, V0, k0, alphav))  # -
+                       # 1.0j * kv * b * z) * r
+
+    if integration_type == "quad":
+        # Integration order is from the last to first arguments
+        # So z, theta, then r
+        value, error = tplquad(integrand, 0, r_bounds[1],
+                               lambda r: 0.0, lambda r: 2 * np.pi,
+                               lambda r, theta: z_bounds[0],
+                               lambda r, theta: z_bounds[1],
+                               **integration_kwargs)
+    elif integration_type == 'mc':
+        if not VEGAS_IMPORT_FLAG:
+            raise ImportError("Monte Carlo integration require the vegas "
+                              "package.")
+        integ = vegas.Integrator([z_bounds,
+                                  [0, 2 * np.pi],
+                                  r_bounds])
+
+        def wrap_integrand(vals):
+            z, r, theta = vals
+            return integrand(z, r, theta)
+
+        result = integ(wrap_integrand, **integration_kwargs)
+        value = result.mean
+        error = np.sqrt(result.var)
+
+    return P0 * fk2 * value, P0 * fk2 * error
+    # return P0 * value, P0 * error
+
+
+k_B = const.k_B.to(u.J / u.K).value
+m_p = const.m_p.to(u.kg).value
+
+
+def f_k(kv, T):
+    return np.exp(- 0.5 * k_B * T * kv**2 / m_p)
+
+
+# Window functions and related
+
+
+def window_function(r, z, beam_type, object_type, los_type, sigma_z=None,
+                    z0=None, z1=None, theta0=None):
+    '''
+    Return the window auto-correlation function for a variety of cases.
+    '''
+
+    beam_types = ['pencil', 'gaussian']
+    object_types = ['slab', 'gaussian']
+    los_types = ['parallel', 'crossing']
+
+    if beam_type not in beam_types:
+        raise ValueError("beam_type must be one of {}".format(beam_types))
+    if object_type not in object_types:
+        raise ValueError("object_type must be one of "
+                         "{}".format(object_types))
+    if los_type not in los_types:
+        raise ValueError("los_type must be one of {}".format(los_types))
+
+    if beam_type == 'pencil':
+        # los_type has no effect hasa
+        if object_type == 'slab':
+            return pencil_beam_slab_z(z, z0, z1)
+        else:
+            # Gaussian case
+            return pencil_beam_gaussian_z(z, sigma_z)
+    else:
+        if object_type == 'slab':
+            if los_type == 'parallel':
+                return gaussian_beam_slab_z_parallel(r, z, z0, z1, theta0)
+            else:
+                # Crossing
+                return gaussian_beam_slab_z_crossing(r, z, z0, z1, theta0)
+        else:
+            # Gaussian
+            if los_type == 'parallel':
+                return gaussian_beam_gaussian_z_parallel(r, z, z0, sigma_z,
+                                                         theta0)
+            else:
+                raise NotImplementedError("The gaussian beam, gaussian LOS "
+                                          "structure in the parallel limit is"
+                                          " not implemented.")


### PR DESCRIPTION
Adding the full VCS models based on the underlying theory. The model is described in [Chepurnov et al. 2015](https://ui.adsabs.harvard.edu/#abs/2015ApJ...810...33C/abstract), [Chepurnov et al. 2010](https://ui.adsabs.harvard.edu/#abs/2010ApJ...714.1398C/abstract), and [Chepurnov & Lazarian 2006](https://ui.adsabs.harvard.edu/#abs/2006astro.ph.11465C/abstract).

Remaining issues:

* Chepurnov+2015 describe a normalization procedure for the emissivity component, which includes a normalized form of the fourier transform of the window functions. Only the normalization part for the emissivity spectrum is implemented and this can overestimate the window functions.
* Limits on the volume integral need to be checked.
* The model requires numerically integrating many times for each data point... and this makes things rather slow. The underlying functions are implemented in cython and this gets the evaluation down to ~1/2 sec. per data point.
* The volume integral can be very slow to do in quadrature. Monte Carlo integration is used instead from the [vegas](https://github.com/gplepage/vegas). The package will be added to the list of optional dependencies.