### PR TITLE
Fix testing grid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,10 @@ matrix:
                CONDA_DEPENDENCIES='pytest scipy matplotlib pandas statsmodels scikit-learn mock sphinx_bootstrap_theme'
 
         # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
-        - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
+        # astropy dev is now >=3.5 only
+        # - os: linux
+        #   env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
+        #        EVENT_TYPE='pull_request push cron'
         - os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
         # Do a coverage test.
         - os: linux
           env: SETUP_CMD='test --coverage'
-
+               PIP_DEPENDENCIES='emcee git+https://github.com/radio-astro-tools/radio_beam.git git+https://github.com/dendrograms/astrodendro.git git+https://github.com/radio-astro-tools/spectral-cube.git'
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - os: linux

--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #166 - Removed testing python 2.7 with the dev version of astropy.
 * #164 - Add segmented linear fitting for the wavelet transform; updated unit test values to include segmented fitting slopes for wavelets
 * #163 - Use Hermitian eigenvalue decomposition for PCA (fixes getting imaginary components); Update the ellipse contour fitting to use the robust fitter from skimage (fixes previous PCA test failures); updated unit test values for the change in PCA
 * #161 - python 3 support; use ci-helpers; updated astropy-helpers; consistent convolution results with astropy 2.x; new delta-variance regression test values after convolution updates; DeltaVariance_Distance.curve_distance now restricts to the region between xlow and xhigh

--- a/turbustat/tests/test_load_beam.py
+++ b/turbustat/tests/test_load_beam.py
@@ -52,13 +52,13 @@ def test_load_beam_props(major, minor, pa):
 
 
 # radio-beam no has an exception for when no beam is found.
-@pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
+@pytest.mark.skipif("RADIO_BEAM_INSTALLED")
 @pytest.mark.xfail(raises=NoBeamException)
 def test_load_beam_fail():
 
     find_beam_width(header)
 
-@pytest.mark.skipif("RADIO_BEAM_INSTALLED")
+@pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
 @pytest.mark.xfail(raises=ValueError)
 def test_load_beam_fail():
 

--- a/turbustat/tests/test_load_beam.py
+++ b/turbustat/tests/test_load_beam.py
@@ -52,11 +52,12 @@ def test_load_beam_props(major, minor, pa):
 
 
 # radio-beam no has an exception for when no beam is found.
-@pytest.mark.skipif("RADIO_BEAM_INSTALLED")
-@pytest.mark.xfail(raises=NoBeamException)
-def test_load_beam_fail():
+# @pytest.mark.skipif("RADIO_BEAM_INSTALLED")
+if RADIO_BEAM_INSTALLED:
+    @pytest.mark.xfail(raises=NoBeamException)
+    def test_load_beam_fail():
 
-    find_beam_width(header)
+        find_beam_width(header)
 
 @pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
 @pytest.mark.xfail(raises=ValueError)

--- a/turbustat/tests/test_load_beam.py
+++ b/turbustat/tests/test_load_beam.py
@@ -58,9 +58,9 @@ if RADIO_BEAM_INSTALLED:
     def test_load_beam_fail():
 
         find_beam_width(header)
+else:
+    # @pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
+    @pytest.mark.xfail(raises=ValueError)
+    def test_load_beam_fail():
 
-@pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
-@pytest.mark.xfail(raises=ValueError)
-def test_load_beam_fail():
-
-    find_beam_width(header)
+        find_beam_width(header)

--- a/turbustat/tests/test_load_beam.py
+++ b/turbustat/tests/test_load_beam.py
@@ -4,6 +4,12 @@ from __future__ import print_function, absolute_import, division
 import pytest
 import astropy.units as u
 
+try:
+    from radio_beam.beam import NoBeamException
+    RADIO_BEAM_INSTALLED = True
+except ImportError:
+    RADIO_BEAM_INSTALLED = False
+
 from ._testing_data import header
 from ..io import find_beam_width, find_beam_properties
 
@@ -45,7 +51,15 @@ def test_load_beam_props(major, minor, pa):
         assert bpa == pa * u.deg
 
 
-@pytest.mark.xfail(raises=(ValueError, TypeError))
+# radio-beam no has an exception for when no beam is found.
+@pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
+@pytest.mark.xfail(raises=NoBeamException)
+def test_load_beam_fail():
+
+    find_beam_width(header)
+
+@pytest.mark.skipif("RADIO_BEAM_INSTALLED")
+@pytest.mark.xfail(raises=ValueError)
 def test_load_beam_fail():
 
     find_beam_width(header)

--- a/turbustat/tests/test_load_beam.py
+++ b/turbustat/tests/test_load_beam.py
@@ -52,9 +52,10 @@ def test_load_beam_props(major, minor, pa):
 
 
 # radio-beam no has an exception for when no beam is found.
-@pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
-@pytest.mark.xfail(raises=NoBeamException)
-def test_load_beam_fail():
+# @pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
+if RADIO_BEAM_INSTALLED:
+    @pytest.mark.xfail(raises=NoBeamException)
+    def test_load_beam_fail():
 
-    find_beam_width(header)
+        find_beam_width(header)
 

--- a/turbustat/tests/test_load_beam.py
+++ b/turbustat/tests/test_load_beam.py
@@ -52,15 +52,9 @@ def test_load_beam_props(major, minor, pa):
 
 
 # radio-beam no has an exception for when no beam is found.
-# @pytest.mark.skipif("RADIO_BEAM_INSTALLED")
-if RADIO_BEAM_INSTALLED:
-    @pytest.mark.xfail(raises=NoBeamException)
-    def test_load_beam_fail():
+@pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
+@pytest.mark.xfail(raises=NoBeamException)
+def test_load_beam_fail():
 
-        find_beam_width(header)
-else:
-    # @pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
-    @pytest.mark.xfail(raises=ValueError)
-    def test_load_beam_fail():
+    find_beam_width(header)
 
-        find_beam_width(header)


### PR DESCRIPTION
astropy dev no longer supports python 2. Drop it from the testing grid.