### PR TITLE
Fixing elliptical parameters in 2D model

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #189 - Fixing elliptical p-law parameters for isotropic fields.
 * $187 - Correct normalization in 3D power-law fields.
 * #186 - Generate mock PPV cubes and 3D power-law fields; added tests for generated power-law in 2D and 3D; renamed `data_reduction` to `moments`; removed masking procedures from `Mask_and_Moments` and renamed to `Moments`
 * #185 - Correct SCF weighting for the distance metric. Addresses #184.

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -320,7 +320,7 @@ class StatisticBase_PSpec2D(object):
             limit have been given.
         radial_weighting : bool, optional
             To account for the increasing number of samples at greater radii,
-            the fit can be weighted by :math:`1/{\rm radius}` to emphasize the
+            the fit can be weighted by :math:`1/\mathrm{radius}` to emphasize the
             points at small radii. DO NOT enabled weighting when the field is
             elliptical! This will bias the fit parameters! Default is False.
         fix_ellip_params : bool, optional

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -320,7 +320,7 @@ class StatisticBase_PSpec2D(object):
             limit have been given.
         radial_weighting : bool, optional
             To account for the increasing number of samples at greater radii,
-            the fit can be weighted by :math:`1/\mathrm{radius}` to emphasize the
+            the fit can be weighted by :math:`1/\\mathrm{radius}` to emphasize the
             points at small radii. DO NOT enabled weighting when the field is
             elliptical! This will bias the fit parameters! Default is False.
         fix_ellip_params : bool, optional

--- a/turbustat/tests/test_ellipplaw.py
+++ b/turbustat/tests/test_ellipplaw.py
@@ -45,10 +45,13 @@ def test_simple_ellipplaw():
 
 @pytest.mark.parametrize(('plaw', 'ellip', 'theta'),
                          [(plaw, ellip, theta) for plaw in [2, 3, 4]
-                          for ellip in [0.2, 0.5, 0.75, 0.9, 1.0]
+                          for ellip in [0.2, 0.5, 0.75, 0.9]
                           for theta in [np.pi / 4., np.pi / 2.,
                                         2 * np.pi / 3., np.pi]])
-def test_simple_ellipplaw_2D(plaw, ellip, theta):
+def test_simple_ellipplaw_2D_anisotropic(plaw, ellip, theta):
+
+    # Must have ellip < 1 for this test. Just be sure...
+    assert ellip < 1.
 
     imsize = 256
 
@@ -87,15 +90,89 @@ def test_simple_ellipplaw_2D(plaw, ellip, theta):
     npt.assert_allclose(-plaw, test_fit[-1], atol=0.1)
 
     npt.assert_allclose(ellip, inverse_interval_transform(test_fit[1], 0, 1),
-                        atol=0.02)
+                        atol=0.01)
 
-    # Theta doesn't matter in the circular case
-    if ellip != 1:
-        # Theta can wrap by pi
-        fit_theta = test_fit[2] % np.pi
+    # Theta can wrap by pi
+    fit_theta = test_fit[2] % np.pi
 
-        if np.abs(fit_theta - theta) > np.abs(fit_theta - theta + np.pi):
-            theta = (theta - np.pi) % np.pi
+    if np.abs(fit_theta - theta) > np.abs(fit_theta - theta + np.pi):
+        theta = (theta - np.pi) % np.pi
 
-        npt.assert_allclose(theta, fit_theta,
-                            atol=0.08)
+    npt.assert_allclose(theta, fit_theta, atol=0.01)
+
+
+@pytest.mark.parametrize('plaw', [2, 3, 4])
+def test_simple_ellipplaw_2D_isotropic(plaw):
+
+    # Must have ellip = 1 for this test. Just be sure...
+    ellip = 1.
+
+    # Theta doesn't matter, but we'll test for what happens when the
+    # elliptical parameters are left free.
+    theta = np.pi / 2.
+
+    imsize = 256
+
+    # Generate a red noise model
+    psd = make_extended(imsize, powerlaw=plaw, ellip=ellip, theta=theta,
+                        return_fft=True)
+
+    psd = np.abs(psd)**2
+
+    # Initial guesses are based on the azimuthally-average spectrum, so it's
+    # valid to give it good initial guesses for the index
+    # Guess it is fairly elliptical. Tends not to be too sensitive to this.
+    ellip_transf = interval_transform(ellip, 0, 1.)
+    # We fit twice w/ thetas offset by pi / 2, so theta also should not be too
+    # sensitive.
+    p0 = (3.7, ellip_transf, np.pi / 2., plaw)
+
+    yy, xx = np.mgrid[-imsize / 2:imsize / 2, -imsize / 2:imsize / 2]
+
+    # Don't fit the 0, 0 point. It isn't defined by the model.
+    valids = psd != 0.
+
+    assert np.isfinite(psd[valids]).all()
+    assert (psd[valids] > 0.).all()
+
+    # First fit with the elliptical parameters left free.
+    test_fit, test_stderr = \
+        fit_elliptical_powerlaw(np.log10(psd[valids]),
+                                xx[valids], yy[valids], p0,
+                                bootstrap=False)[:2]
+
+    # Do the parameters match?
+
+    # Require the index to be within 0.1 of the actual,
+    # the ellipticity to be within 0.02, and the theta to be within ~3 deg
+
+    npt.assert_allclose(-plaw, test_fit[-1], atol=0.1)
+
+    npt.assert_allclose(ellip, inverse_interval_transform(test_fit[1], 0, 1),
+                        atol=0.01)
+
+    # Ensure fixing the elliptical parameters is working
+    # And check that bootstrapping keeps those params fixed.
+    test_fit, test_stderr = \
+        fit_elliptical_powerlaw(np.log10(psd[valids]),
+                                xx[valids], yy[valids], p0,
+                                bootstrap=True, niters=2,
+                                fix_ellip_params=True,
+                                radial_weighting=True)[:2]
+
+    # Should have a great constraint on the slope now
+    npt.assert_allclose(-plaw, test_fit[-1], atol=0.001)
+
+    # Transformed ellip should be inf
+    assert np.isinf(test_fit[1])
+    # Transforming back should give 1.0
+    assert inverse_interval_transform(test_fit[1], 0, 1) == 1.
+
+    # Theta should be the original
+    assert theta == np.pi / 2.
+
+    # Ellip param will be a NaN b/c it stays at inf
+    assert np.isnan(test_stderr[1])
+
+    # And theta should not move
+    assert test_stderr[2] == 0.


### PR DESCRIPTION
The 2D elliptical power-law model can be difficult to fit in the isotropic case because `ellip=1` is at the edge of parameter space, making it hard to optimize. This PR adds the option to fix the ellip and theta parameters in the model for fitting an isotropic model. There is also a warning for all power-law methods to try fitting with fixed parameters when the ellipticity is close to 1.

Also added a radial weighting option when fitting a 2D power-law. This should make the fitted slope converge to the binned 1D slope by down-weighting points at large radii, where there are more samples to fit to. BUT this biases the fit parameters if the field is anisotropic. A warning is raised in this case.