### PR TITLE
Downsample to change slice thickness

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #190 - Add spectral downsampling by averaging for VCA; remove downsampling for VCS.
 * #189 - Fixing elliptical p-law parameters for isotropic fields.
 * $187 - Correct normalization in 3D power-law fields.
 * #186 - Generate mock PPV cubes and 3D power-law fields; added tests for generated power-law in 2D and 3D; renamed `data_reduction` to `moments`; removed masking procedures from `Mask_and_Moments` and renamed to `Moments`

--- a/turbustat/statistics/vca_vcs/slice_thickness.py
+++ b/turbustat/statistics/vca_vcs/slice_thickness.py
@@ -8,83 +8,125 @@ from astropy.convolution import Gaussian1DKernel
 from warnings import warn
 
 
-def spectral_regrid_cube(cube, channel_width):
+def spectral_regrid_cube(cube, channel_width, method='downsample',
+                         downsamp_function=np.nanmean):
     '''
-    Spectrally regrid a SpectralCube to a given channel width. The data are
-    first spectrally smoothed with a Gaussian kernel. The kernel width is
-    the target channel width deconvolved from the current channel width
-    (http://spectral-cube.readthedocs.io/en/latest/smoothing.html#spectral-smoothing).
+    Spectrally regrid a SpectralCube to a given channel width. There are two
+    options for regridding:
 
-    Note that, in order to ensure the regridded cube covers the same spectral
+    * `method='downsample'` -- The data are downsampled by averaging over an
+    integer number of channels. The initial assumption is that the
+    channels are uncorrelated. This is the default setting.
+
+    * `method='regrid'` -- The data are spectrally smoothed with a Gaussian
+    kernel. The kernel width is the target channel width deconvolved from
+    the current channel width
+    (http://spectral-cube.readthedocs.io/en/latest/smoothing.html#spectral-smoothing).
+    In order to ensure the regridded cube covers the same spectral
     range, the smoothed cube may have channels that differ slightly from the
     given width. The number of channels is chosen to be the next lowest
     integer when dividing the original number of channels by the ratio of the
     new and old channel widths.
 
+    Typically the downsample method should be used. If the channel widths is
+    being increased by less than the line width, there will not be a
+    substantial difference in the power-law slopes using the different methods.
+    However, the prior smoothing required for the interpolation step with
+    `method='regrid'` makes the effective channel width wider. This effect
+    should be accounted for when estimating the transition from the thin to
+    thick velocity regimes (e.g., in VCA), as the channel
+    size will not be the effective channel width when using this method.
+
     Parameters
     ----------
     cube : `~spectral_cube.SpectralCube`
         Spectral cube to regrid.
-    channel_width : `~astropy.units.Quantity`
-        The width of the new channels. This should be given in equivalent
-        spectral units used in the cube, or in pixel units. For example,
-        downsampling by a factor of 2 for a cube with a channel width of
-        0.1 km/s can be achieved by setting `channel_width` to `2 * u.pix`
-        or `0.2 km /s`.
+    channel_width : `~astropy.units.Quantity` or int
+        The width of the new channels. If `method='regrid'`, `channel_width`
+        should be given in equivalent spectral units used in the cube, or
+        in pixel units. For example, downsampling by a factor of 2 for a cube
+        with a channel width of 0.1 km/s can be achieved by setting
+        `channel_width` to `2 * u.pix`
+        or `0.2 km /s`. If `method='downsample'`, `channel_width` must be
+        an integer. This sets the number of channels to downsample across.
+    method : {'downsample', 'regrid'}, optional
+        Method to spectrally regrid the cube.
+    downsamp_function : {function}, optional
+        The operation to apply when downsampling. Defaults to
+        `~numpy.nanmean`.
 
     Returns
     -------
     regridded_cube : `spectral_cube.SpectralCube`
-        The smoothed and regridded cube.
+        The regridded or downsampled cube.
     '''
 
     if not isinstance(cube, BaseSpectralCube):
         raise TypeError("`cube` must be a SpectralCube object.")
 
-    if not isinstance(channel_width, u.Quantity):
-        raise TypeError("channel_width must be an astropy.units.Quantity.")
+    if method not in ['regrid', 'downsample']:
+        raise ValueError("method must be 'regrid' or 'downsample'. {} was"
+                         " given".format(method))
 
-    fwhm_factor = np.sqrt(8 * np.log(2))
+    if method == 'downsample':
 
-    pix_unit = channel_width.unit.is_equivalent(u.pix)
+        if not isinstance(channel_width, int):
+            raise TypeError("channel_width must be an integer when using "
+                            "method='downsample'.")
 
-    spec_width = np.diff(cube.spectral_axis[:2])[0]
+        return cube.downsample_axis(channel_width, axis=0)
 
-    current_resolution = np.diff(cube.spectral_axis[:2])[0]
-
-    if pix_unit:
-        target_resolution = channel_width.value * spec_width
     else:
-        target_resolution = channel_width.to(current_resolution.unit)
+        # Must then be regrid
 
-    diff_factor = np.abs(target_resolution / current_resolution).value
+        if not isinstance(channel_width, u.Quantity):
+            raise TypeError("channel_width must be an "
+                            "astropy.units.Quantity when using "
+                            "method='regrid'.")
 
-    if diff_factor == 1:
-        warn("The requested channel width match the original channel width. "
-             "The original cube is returned.")
-        return cube
+        fwhm_factor = np.sqrt(8 * np.log(2))
 
-    if diff_factor < 1:
-        raise ValueError("Only down-sampling the spectral grid is supported. "
-                         "The requested channel width of {0} is a factor {1} "
-                         "smaller than the original channel width."
-                         .format(target_resolution, diff_factor))
+        pix_unit = channel_width.unit.is_equivalent(u.pix)
 
-    pixel_scale = np.abs(current_resolution)
+        spec_width = np.diff(cube.spectral_axis[:2])[0]
 
-    gaussian_width = ((target_resolution**2 - current_resolution**2)**0.5 /
-                      pixel_scale / fwhm_factor)
-    kernel = Gaussian1DKernel(gaussian_width)
-    new_cube = cube.spectral_smooth(kernel)
+        current_resolution = np.diff(cube.spectral_axis[:2])[0]
 
-    # Now define the new spectral axis at the new resolution
-    num_chan = int(np.floor_divide(cube.shape[0], diff_factor))
-    new_specaxis = np.linspace(cube.spectral_axis.min().value,
-                               cube.spectral_axis.max().value,
-                               num_chan) * current_resolution.unit
-    # Keep the same order (max to min or min to max)
-    if current_resolution.value < 0:
-        new_specaxis = new_specaxis[::-1]
+        if pix_unit:
+            target_resolution = channel_width.value * spec_width
+        else:
+            target_resolution = channel_width.to(current_resolution.unit)
 
-    return new_cube.spectral_interpolate(new_specaxis,
-                                         suppress_smooth_warning=True)
+        diff_factor = np.abs(target_resolution / current_resolution).value
+
+        if diff_factor == 1:
+            warn("The requested channel width match the original channel "
+                 "width. The original cube is returned.")
+            return cube
+
+        if diff_factor < 1:
+            raise ValueError("Only down-sampling the spectral grid is"
+                             " supported. The requested channel width of {0}"
+                             " is a factor {1} "
+                             "smaller than the original channel width."
+                             .format(target_resolution, diff_factor))
+
+        pixel_scale = np.abs(current_resolution)
+
+        gaussian_width = ((target_resolution**2 - current_resolution**2)**0.5 /
+                          pixel_scale / fwhm_factor)
+        kernel = Gaussian1DKernel(gaussian_width)
+        new_cube = cube.spectral_smooth(kernel)
+
+        # Now define the new spectral axis at the new resolution
+        num_chan = int(np.floor_divide(cube.shape[0], diff_factor))
+        new_specaxis = np.linspace(cube.spectral_axis.min().value,
+                                   cube.spectral_axis.max().value,
+                                   num_chan) * current_resolution.unit
+
+        # Keep the same order (max to min or min to max)
+        if current_resolution.value < 0:
+            new_specaxis = new_specaxis[::-1]
+
+        return new_cube.spectral_interpolate(new_specaxis,
+                                             suppress_smooth_warning=True)

--- a/turbustat/statistics/vca_vcs/vca.py
+++ b/turbustat/statistics/vca_vcs/vca.py
@@ -26,21 +26,23 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
         Data cube.
     header : FITS header, optional
         Corresponding FITS header.
+    distance : `~astropy.units.Quantity`, optional
+        Physical distance to the region in the data.
+    beam : `radio_beam.Beam`, optional
+        Beam object for correcting for the effect of a finite beam.
     channel_width : `~astropy.units.Quantity`, optional
         Set the width of channels to compute the VCA with. The channel width
         in the data is used by default. Given widths will be used to
         spectrally down-sample the data before calculating the VCA. Up-sampling
         to smaller channel sizes than the original is not supported.
-    distance : `~astropy.units.Quantity`, optional
-        Physical distance to the region in the data.
-    beam : `radio_beam.Beam`, optional
-        Beam object for correcting for the effect of a finite beam.
+    downsample_kwargs : dict, optional
+        Passed to `~turbustat.statistics.vca_vca.slice_thickness.spectral_regrid_cube`.
     '''
 
     __doc__ %= {"dtypes": " or ".join(common_types + threed_types)}
 
-    def __init__(self, cube, header=None, channel_width=None, distance=None,
-                 beam=None):
+    def __init__(self, cube, header=None, distance=None, beam=None,
+                 channel_width=None, downsample_kwargs={}):
         super(VCA, self).__init__()
 
         self.input_data_header(cube, header)
@@ -49,7 +51,8 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
         if channel_width is not None:
             sc_cube = to_spectral_cube(self.data, self.header)
 
-            reg_cube = spectral_regrid_cube(sc_cube, channel_width)
+            reg_cube = spectral_regrid_cube(sc_cube, channel_width,
+                                            **downsample_kwargs)
 
             # Don't pass the header. It will read the new one in reg_cube
             self.input_data_header(reg_cube, None)

--- a/turbustat/statistics/vca_vcs/vcs.py
+++ b/turbustat/statistics/vca_vcs/vcs.py
@@ -28,11 +28,6 @@ class VCS(BaseStatisticMixIn):
         Corresponding FITS header.
     vel_units : bool, optional
         Convert frequencies to the spectral unit in the header.
-    channel_width : `~astropy.units.Quantity`, optional
-        Set the width of channels to compute the VCA with. The channel width
-        in the data is used by default. Given widths will be used to
-        spectrally down-sample the data before calculating the VCA. Up-sampling
-        to smaller channel sizes than the original is not supported.
     '''
 
     __doc__ %= {"dtypes": " or ".join(common_types + threed_types)}
@@ -41,14 +36,6 @@ class VCS(BaseStatisticMixIn):
         super(VCS, self).__init__()
 
         self.input_data_header(cube, header)
-
-        if channel_width is not None:
-            sc_cube = to_spectral_cube(self.data, self.header)
-
-            reg_cube = spectral_regrid_cube(sc_cube, channel_width)
-
-            # Don't pass the header. It will read the new one in reg_cube
-            self.input_data_header(reg_cube, None)
 
         self._has_nan_flag = False
         if np.isnan(self.data).any():

--- a/turbustat/tests/test_vcs.py
+++ b/turbustat/tests/test_vcs.py
@@ -51,18 +51,6 @@ def test_VCS_distance():
                             computed_distances['vcs_distance'])
 
 
-def test_VCS_method_change_chanwidth():
-
-    orig_width = np.abs(dataset1['cube'][1]["CDELT3"]) * u.m / u.s
-
-    tester = VCS(dataset1["cube"], channel_width=2 * orig_width)
-
-    # Should have 250 channels now
-    assert tester.data.shape[0] == 250
-
-    tester.run()
-
-
 def test_VCS_method_fitlimits():
 
     high_cut = 0.17 / u.pix


### PR DESCRIPTION
The VCA technique relies on measuring the power-spectrum slope with different spectral channel widths. Prior to this PR, spectral downsampling smoothed then interpolated to a lower spectral resolution.  However, downsampling by averaging over an integer number of channels is closer to what has previously been used in the literature. This PR adds the latter method and makes it the default method for downsampling.

Downsampling has also been removed from the VCS, since this only acts to change the limits of the VCS extent.