### PR TITLE
Add stddev to Wavelet

### DIFF
--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -115,8 +115,7 @@ class StatisticBase_PSpec2D(object):
             Sets the minimum number of points needed to fit. If not met, the
             break found is rejected.
         weighted_fit : bool, optional
-            Fit using weighted least-squares. Requires `return_stddev` to be
-            enabled when computing the radial power-spectrum. The weights are
+            Fit using weighted least-squares. The weights are
             the inverse-squared standard deviations in each radial bin.
         bootstrap : bool, optional
             Bootstrap using the model residuals to estimate the parameter
@@ -169,8 +168,12 @@ class StatisticBase_PSpec2D(object):
                     assert brk.unit == u.dimensionless_unscaled
                     brk = brk.value
 
-            brk_fit = \
-                Lm_Seg(x, y, brk)
+            if weighted_fit:
+                weights = 1 / y_err**2
+            else:
+                weights = None
+
+            brk_fit = Lm_Seg(x, y, brk, weights=weights)
             brk_fit.fit_model(verbose=verbose, cov_type='HC3')
 
             if brk_fit.params.size == 5:

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -149,10 +149,6 @@ class StatisticBase_PSpec2D(object):
 
         if weighted_fit:
 
-            if brk is not None:
-                raise ValueError("Weighted least-squares fitting cannot be "
-                                 "used when fitting a break-point.")
-
             y_err = np.log10(self.ps1D_stddev[clip_func(self.freqs.value,
                                                         self.low_cut.value,
                                                         self.high_cut.value)])

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -144,14 +144,21 @@ class StatisticBase_PSpec2D(object):
 
         x = np.log10(self.freqs[clip_func(self.freqs.value, self.low_cut.value,
                                           self.high_cut.value)].value)
-        y = np.log10(self.ps1D[clip_func(self.freqs.value, self.low_cut.value,
-                                         self.high_cut.value)])
+
+        clipped_ps1D = self.ps1D[clip_func(self.freqs.value,
+                                           self.low_cut.value,
+                                           self.high_cut.value)]
+        y = np.log10(clipped_ps1D)
 
         if weighted_fit:
 
-            y_err = np.log10(self.ps1D_stddev[clip_func(self.freqs.value,
+            clipped_stddev = self.ps1D_stddev[clip_func(self.freqs.value,
                                                         self.low_cut.value,
-                                                        self.high_cut.value)])
+                                                        self.high_cut.value)]
+
+            clipped_stddev[clipped_stddev == 0.] = np.NaN
+
+            y_err = 0.434 * clipped_stddev / clipped_ps1D
 
         if brk is not None:
             # Try the fit with a break in it.

--- a/turbustat/statistics/delta_variance/delta_variance.py
+++ b/turbustat/statistics/delta_variance/delta_variance.py
@@ -113,7 +113,10 @@ class DeltaVariance(BaseStatisticMixIn):
             raise ValueError("At least one of the lags is smaller than one "
                              "pixel. Remove these lags from the array.")
 
-        if np.any(pix_lags.value > min(self.data.shape) / 2.):
+        # Catch floating point issues in comparing to half the image shape
+        half_comp = (np.floor(pix_lags.value) - min(self.data.shape) / 2.)
+
+        if np.any(half_comp > 1e-10):
             raise ValueError("At least one of the lags is larger than half of"
                              " the image size. Remove these lags from the "
                              "array.")

--- a/turbustat/statistics/lm_seg.py
+++ b/turbustat/statistics/lm_seg.py
@@ -70,7 +70,7 @@ class Lm_Seg(object):
             raise Warning("Not enough finite points to fit.")
 
     def fit_model(self, tol=1e-3, iter_max=100, h_step=2.0, epsil_0=10,
-                  constant=True, verbose=True, **fit_kwargs):
+                  constant=True, verbose=True, missing='drop', **fit_kwargs):
         '''
         '''
         # Fit a normal linear model to the data
@@ -81,9 +81,10 @@ class Lm_Seg(object):
             x_const = self.x
 
         if self.weights is None:
-            model = sm.OLS(self.y, x_const)
+            model = sm.OLS(self.y, x_const, missing=missing)
         else:
-            model = sm.WLS(self.y, x_const, weights=self.weights)
+            model = sm.WLS(self.y, x_const, weights=self.weights,
+                           missing=missing)
         init_lm = model.fit(**fit_kwargs)
 
         if verbose:
@@ -117,9 +118,10 @@ class Lm_Seg(object):
                 X_all = sm.add_constant(X_all)
 
             if self.weights is None:
-                model = sm.OLS(self.y, X_all)
+                model = sm.OLS(self.y, X_all, missing=missing)
             else:
-                model = sm.WLS(self.y, X_all, weights=self.weights)
+                model = sm.WLS(self.y, X_all, weights=self.weights,
+                               missing=missing)
             fit = model.fit()
 
             beta = fit.params[2]  # Get coef
@@ -188,9 +190,10 @@ class Lm_Seg(object):
             X_all = sm.add_constant(X_all)
 
         if self.weights is None:
-            model = sm.OLS(self.y, X_all)
+            model = sm.OLS(self.y, X_all, missing=missing)
         else:
-            model = sm.WLS(self.y, X_all, weights=self.weights)
+            model = sm.WLS(self.y, X_all, weights=self.weights,
+                           missing=missing)
 
         self.fit = model.fit()
         self._params = self.fit.params

--- a/turbustat/statistics/wavelets/wavelet_transform.py
+++ b/turbustat/statistics/wavelets/wavelet_transform.py
@@ -98,6 +98,7 @@ class Wavelet(BaseStatisticMixIn):
         self._scales = values
 
     def compute_transform(self, show_progress=True, scale_normalization=True,
+                          keep_convolved_arrays=False,
                           use_pyfftw=False, threads=1, pyfftw_kwargs={}):
         '''
         Compute the wavelet transform at each scale.
@@ -109,6 +110,9 @@ class Wavelet(BaseStatisticMixIn):
         scale_normalization: bool, optional
             Compute the transform with the correct scale-invariant
             normalization.
+        keep_convolved_arrays: bool, optional
+            Keep the image convolved at all wavelet scales. For large images,
+            this can require a large amount memory. Default is False.
         use_pyfftw : bool, optional
             Enable to use pyfftw, if it is installed.
         threads : int, optional
@@ -133,7 +137,13 @@ class Wavelet(BaseStatisticMixIn):
         n0, m0 = self.data.shape
         A = len(self.scales)
 
-        self._Wf = np.zeros((A, n0, m0), dtype=np.float)
+        if keep_convolved_arrays:
+            self._Wf = np.zeros((A, n0, m0), dtype=np.float)
+        else:
+            self._Wf = None
+
+        self._values = np.empty_like(self.scales.value)
+        self._stddev = np.empty_like(self.scales.value)
 
         factor = 2
         if not scale_normalization:
@@ -150,10 +160,16 @@ class Wavelet(BaseStatisticMixIn):
         for i, an in enumerate(pix_scales):
             psi = MexicanHat2DKernel(an)
 
-            self._Wf[i] = \
+            conv_arr = \
                 convolve_fft(self.data, psi, normalize_kernel=False,
                              fftn=use_fftn, ifftn=use_ifftn).real * \
                 an**factor
+
+            if keep_convolved_arrays:
+                self._Wf[i] = conv_arr
+
+            self._values[i] = (conv_arr[conv_arr > 0]).mean()
+            self._stddev[i] = (conv_arr[conv_arr > 0]).std()
 
             if show_progress:
                 bar.update(i + 1)
@@ -164,16 +180,11 @@ class Wavelet(BaseStatisticMixIn):
         The wavelet transforms of the image. Each plane is the transform at
         different wavelet sizes.
         '''
+        if self._Wf is None:
+            warn("`keep_convolved_arrays` was disabled in "
+                 "`compute_transform`.")
+
         return self._Wf
-
-    def make_1D_transform(self):
-        '''
-        Create the 1D transform.
-        '''
-
-        self._values = np.empty_like(self.scales.value)
-        for i, plane in enumerate(self.Wf):
-            self._values[i] = (plane[plane > 0]).mean()
 
     @property
     def values(self):
@@ -182,9 +193,16 @@ class Wavelet(BaseStatisticMixIn):
         '''
         return self._values
 
+    @property
+    def stddev(self):
+        '''
+        Standard deviation of the 1-dimensional wavelet transform.
+        '''
+        return self._stddev
+
     def fit_transform(self, xlow=None, xhigh=None, brk=None, min_fits_pts=3,
-                      bootstrap=False, bootstrap_kwargs={},
-                      **fit_kwargs):
+                      weighted_fit=False, bootstrap=False,
+                      bootstrap_kwargs={}, **fit_kwargs):
         '''
         Perform a fit to the transform in log-log space.
 
@@ -197,6 +215,12 @@ class Wavelet(BaseStatisticMixIn):
         brk : `~astropy.units.Quantity`, optional
             Give an initial guess for a break point. This enables fitting
             with a `turbustat.statistics.Lm_Seg`.
+        min_fits_pts : int, optional
+            Minimum number of points required above or below the fitted break
+            for it to be considered a valid fit. Only used when a segmented
+            line is fit, i.e. when a value for `brk` is given.
+        weighted_fit: bool, optional
+            Use the `~Wavelet.stddev` to perform a weighted fit.
         bootstrap : bool, optional
             Bootstrap using the model residuals to estimate the standard
             errors.
@@ -208,6 +232,14 @@ class Wavelet(BaseStatisticMixIn):
         pix_scales = self._to_pixel(self.scales)
         x = np.log10(pix_scales.value)
         y = np.log10(self.values)
+
+        if weighted_fit:
+            y_err = 0.434 * self.stddev / self.values
+            y_err[y_err == 0.] = np.NaN
+
+            weights = y_err**-2
+        else:
+            weights = None
 
         if xlow is not None:
             xlow = self._to_pixel(xlow)
@@ -234,6 +266,9 @@ class Wavelet(BaseStatisticMixIn):
         y = y[within_limits]
         x = x[within_limits]
 
+        if weighted_fit:
+            weights = weights[within_limits]
+
         if brk is not None:
             # Try fitting a segmented model
 
@@ -242,7 +277,7 @@ class Wavelet(BaseStatisticMixIn):
             if pix_brk < xlow or pix_brk > xhigh:
                 raise ValueError("brk must be within xlow and xhigh.")
 
-            model = Lm_Seg(x, y, np.log10(pix_brk.value))
+            model = Lm_Seg(x, y, np.log10(pix_brk.value), weights=weights)
 
             fit_kwargs['cov_type'] = 'HC3'
 
@@ -296,7 +331,10 @@ class Wavelet(BaseStatisticMixIn):
 
             x = sm.add_constant(x)
 
-            model = sm.OLS(y, x, missing='drop')
+            if weighted_fit:
+                model = sm.WLS(y, x, missing='drop', weights=weights)
+            else:
+                model = sm.OLS(y, x, missing='drop')
 
             self.fit = model.fit(cov_type='HC3')
 
@@ -508,7 +546,6 @@ class Wavelet(BaseStatisticMixIn):
                                use_pyfftw=use_pyfftw, threads=threads,
                                pyfftw_kwargs=pyfftw_kwargs,
                                show_progress=show_progress)
-        self.make_1D_transform()
         self.fit_transform(xlow=xlow, xhigh=xhigh, brk=brk, **fit_kwargs)
 
         if verbose:

--- a/turbustat/tests/test_bispec.py
+++ b/turbustat/tests/test_bispec.py
@@ -79,7 +79,7 @@ def test_bispec_azimuthal_slicing():
                          [plaw for plaw in [2, 3, 4]])
 def test_bispec_radial_slicing(plaw):
 
-    img = make_extended(256, powerlaw=plaw)
+    img = make_extended(128, powerlaw=plaw)
 
     bispec = Bispectrum(fits.PrimaryHDU(img))
     bispec.run(nsamples=100)

--- a/turbustat/tests/test_delvar.py
+++ b/turbustat/tests/test_delvar.py
@@ -144,7 +144,7 @@ def test_delvar_plaw_img(plaw, ellip):
     should remain the same.
     '''
 
-    imsize = 256
+    imsize = 128
     theta = 0
 
     # Generate a red noise model
@@ -152,14 +152,10 @@ def test_delvar_plaw_img(plaw, ellip):
                         return_fft=False)
 
     test = DeltaVariance(fits.PrimaryHDU(img))
-    test.run()
+    test.run(xhigh=imsize / 4. * u.pix)
 
     # Ensure slopes are consistent to within 2%
     # Relation to the power law slope is plaw - 2
     # Highly elliptical structure (0.2) leads to ~3% deviations
 
-    # Use an abs difference when the delvar should be 0.
-    if plaw == 2.:
-        npt.assert_allclose(plaw - 2., test.slope, atol=0.01)
-    else:
-        npt.assert_allclose(plaw - 2., test.slope, rtol=0.03)
+    npt.assert_allclose(plaw, test.slope + 2., rtol=0.04)

--- a/turbustat/tests/test_ellipplaw.py
+++ b/turbustat/tests/test_ellipplaw.py
@@ -53,7 +53,7 @@ def test_simple_ellipplaw_2D_anisotropic(plaw, ellip, theta):
     # Must have ellip < 1 for this test. Just be sure...
     assert ellip < 1.
 
-    imsize = 256
+    imsize = 128
 
     # Generate a red noise model
     psd = make_extended(imsize, powerlaw=plaw, ellip=ellip, theta=theta,

--- a/turbustat/tests/test_mvc.py
+++ b/turbustat/tests/test_mvc.py
@@ -112,7 +112,7 @@ def test_mvc_azimlimits(plaw, ellip):
     should remain the same.
     '''
 
-    imsize = 256
+    imsize = 128
     theta = 0
 
     # Generate a red noise model
@@ -126,20 +126,20 @@ def test_mvc_azimlimits(plaw, ellip):
     test.run(radial_pspec_kwargs={"theta_0": 0 * u.deg,
                                   "delta_theta": 40 * u.deg},
              fit_2D=False,
-             fit_kwargs={'weighted_fit': True})
+             fit_kwargs={'weighted_fit': False})
 
     test2 = MVC(fits.PrimaryHDU(img), fits.PrimaryHDU(ones),
                 fits.PrimaryHDU(ones))
     test2.run(radial_pspec_kwargs={"theta_0": 90 * u.deg,
                                    "delta_theta": 40 * u.deg},
               fit_2D=False,
-              fit_kwargs={'weighted_fit': True})
+              fit_kwargs={'weighted_fit': False})
 
     test3 = MVC(fits.PrimaryHDU(img), fits.PrimaryHDU(ones),
                 fits.PrimaryHDU(ones))
     test3.run(radial_pspec_kwargs={},
               fit_2D=False,
-              fit_kwargs={'weighted_fit': True})
+              fit_kwargs={'weighted_fit': False})
 
     # Ensure slopes are consistent to within 7%
     assert_between(test3.slope, - 1.07 * plaw, - 0.93 * plaw)
@@ -165,7 +165,7 @@ def test_MVC_method_fftw():
 @pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
 def test_MVC_beamcorrect():
 
-    imsize = 512
+    imsize = 128
     theta = 0
     plaw = 3.0
     ellip = 1.0
@@ -215,7 +215,7 @@ def test_MVC_beamcorrect():
                           'cosinebell'])
 def test_MVC_apod_kernel(apod_type):
 
-    imsize = 512
+    imsize = 256
     theta = 0
     plaw = 3.0
     ellip = 1.0
@@ -234,7 +234,7 @@ def test_MVC_apod_kernel(apod_type):
 
     # Avoid shot noise scatter at large scales
     if apod_type == 'cosinebell':
-        low_cut = 10**-1.1 / u.pix
+        low_cut = 10**-0.8 / u.pix
     else:
         low_cut = 10**-1.4 / u.pix
 

--- a/turbustat/tests/test_pspec.py
+++ b/turbustat/tests/test_pspec.py
@@ -110,7 +110,7 @@ def test_pspec_azimlimits(plaw, ellip):
     should remain the same.
     '''
 
-    imsize = 256
+    imsize = 128
     theta = 0
 
     # Generate a red noise model
@@ -148,7 +148,7 @@ def test_pspec_weightfit(plaw):
     should remain the same.
     '''
 
-    imsize = 256
+    imsize = 64
     theta = 0
 
     # Generate a red noise model
@@ -171,7 +171,7 @@ def test_pspec_fit2D(theta):
     here.
     '''
 
-    imsize = 256
+    imsize = 64
     ellip = 0.5
     plaw = 4.
 
@@ -205,7 +205,7 @@ def test_PSpec_method_fftw():
 @pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
 def test_PSpec_beamcorrect():
 
-    imsize = 512
+    imsize = 128
     theta = 0
     plaw = 3.0
     ellip = 1.0
@@ -251,7 +251,7 @@ def test_PSpec_beamcorrect():
                           'cosinebell'])
 def test_PSpec_apod_kernel(apod_type):
 
-    imsize = 512
+    imsize = 256
     theta = 0
     plaw = 3.0
     ellip = 1.0
@@ -266,11 +266,6 @@ def test_PSpec_apod_kernel(apod_type):
     test = PowerSpectrum(hdu)
 
     # Effects large scales
-    if apod_type == 'cosinebell':
-        low_cut = 10**-1.8 / u.pix
-    else:
-        low_cut = None
-
     low_cut = 10**-1.8 / u.pix
 
     test.run(apodize_kernel=apod_type, alpha=0.3, beta=0.8, fit_2D=False,

--- a/turbustat/tests/test_scf.py
+++ b/turbustat/tests/test_scf.py
@@ -183,8 +183,8 @@ def test_SCF_azimlimits():
 
 @pytest.mark.parametrize(('theta', 'ellip'),
                          [(theta, ellip) for theta in
-                         [0., np.pi / 4., np.pi / 2., 7 * np.pi / 8.]
-                         for ellip in [0.2, 0.5, 0.8]])
+                         [0., np.pi / 4., 7 * np.pi / 8.]
+                          for ellip in [0.2, 0.8]])
 def test_scf_fit2D(theta, ellip):
     '''
     Since test_elliplaw tests everything, only check for consistent theta
@@ -192,7 +192,7 @@ def test_scf_fit2D(theta, ellip):
     '''
 
     nchans = 10
-    imsize = 256
+    imsize = 128
     plaw = 4.
 
     # Generate a red noise model

--- a/turbustat/tests/test_vca.py
+++ b/turbustat/tests/test_vca.py
@@ -151,7 +151,7 @@ def test_vca_azimlimits(plaw, ellip):
     should remain the same.
     '''
 
-    imsize = 512
+    imsize = 128
     theta = 0
 
     nchans = 10
@@ -171,22 +171,22 @@ def test_vca_azimlimits(plaw, ellip):
                                   "theta_0": 0 * u.deg,
                                   "delta_theta": 40 * u.deg},
              fit_2D=False,
-             fit_kwargs={'weighted_fit': True},
-             low_cut=10**-2 / u.pix)
+             fit_kwargs={'weighted_fit': False},
+             low_cut=(4. / imsize) / u.pix)
 
     test2 = VCA(fits.PrimaryHDU(cube))
     test2.run(radial_pspec_kwargs={'binsize': 8.,
                                    "theta_0": 90 * u.deg,
                                    "delta_theta": 40 * u.deg},
               fit_2D=False,
-              fit_kwargs={'weighted_fit': True},
-              low_cut=10**-2 / u.pix)
+              fit_kwargs={'weighted_fit': False},
+              low_cut=(4. / imsize) / u.pix)
 
     test3 = VCA(fits.PrimaryHDU(cube))
     test3.run(radial_pspec_kwargs={'binsize': 8.},
               fit_2D=False,
-              fit_kwargs={'weighted_fit': True},
-              low_cut=10**-2 / u.pix)
+              fit_kwargs={'weighted_fit': False},
+              low_cut=(4. / imsize) / u.pix)
 
     # Ensure slopes are consistent to within 0.1. Shot noise with the
     # limited number of points requires checking within a range.
@@ -209,7 +209,7 @@ def test_VCA_method_fftw():
 @pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
 def test_VCA_beamcorrect():
 
-    imsize = 512
+    imsize = 128
     theta = 0
     plaw = 3.0
     ellip = 1.0
@@ -257,7 +257,7 @@ def test_VCA_beamcorrect():
                           'cosinebell'])
 def test_VCA_apod_kernel(apod_type):
 
-    imsize = 512
+    imsize = 256
     theta = 0
     plaw = 3.0
     ellip = 1.0

--- a/turbustat/tests/test_wavelet.py
+++ b/turbustat/tests/test_wavelet.py
@@ -134,17 +134,18 @@ def test_Wavelet_method_fftw():
     npt.assert_almost_equal(tester.slope, computed_data['wavelet_slope'])
 
 
-@pytest.mark.parametrize(('plaw', 'ellip'),
-                         [(plaw, ellip) for plaw in [2, 3, 4]
-                          for ellip in [0.2, 0.75, 1.0]])
-def test_wavelet_plaw_img(plaw, ellip):
+@pytest.mark.parametrize(('plaw', 'ellip', 'weight'),
+                         [(plaw, ellip, weight) for plaw in [2, 3, 4]
+                          for ellip in [0.2, 1.0]
+                          for weight in [False, True]])
+def test_wavelet_plaw_img(plaw, ellip, weight):
     '''
     The slopes with azimuthal constraints should be the same. When elliptical,
     the power will be different along the different directions, but the slope
     should remain the same.
     '''
 
-    imsize = 256
+    imsize = 128
     theta = 0
 
     # Generate a red noise model
@@ -153,7 +154,7 @@ def test_wavelet_plaw_img(plaw, ellip):
 
     test = Wavelet(fits.PrimaryHDU(img))
     # The turn-over occurs near ~1/16 of the axis size.
-    test.run(xhigh=imsize / 16. * u.pix)
+    test.run(xhigh=imsize / 16. * u.pix, fit_kwargs={'weighted_fit': weight})
 
     # Ensure slopes are consistent to within 2%
     # Relation to the power law slope is (plaw - 2) / 2.


### PR DESCRIPTION
Use the standard deviation of the Wavelet transform and optionally perform weighted fits.

* Also fixes incorrect log-errors for the power-spectrum-based stats
* Reduces image sizes in the testing suite to speed things up