### PR TITLE
Fix plotting for distance metrics

### DIFF
--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -659,8 +659,7 @@ class StatisticBase_PSpec2D(object):
 
         if show_residual:
             ax_1D_res.set_xlabel("log " + xlab)
-
-            # ax_1D.get_xaxis().set_ticks([])
+            ax_1D.get_xaxis().set_ticklabels([])
         else:
             ax_1D.set_xlabel("log " + xlab)
 

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -660,6 +660,7 @@ class StatisticBase_PSpec2D(object):
         if show_residual:
             ax_1D_res.set_xlabel("log " + xlab)
             ax_1D.get_xaxis().set_ticklabels([])
+            ax_1D_res.set_ylabel(r"Residuals")
         else:
             ax_1D.set_xlabel("log " + xlab)
 

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -465,7 +465,7 @@ class StatisticBase_PSpec2D(object):
         '''
         return self._ellip2D_err
 
-    def plot_fit(self, show=True, show_2D=False, show_residual=True,
+    def plot_fit(self, show_2D=False, show_residual=True,
                  color='r', fit_color=None, label=None,
                  fillin_errs=True, symbol="D", xunit=u.pix**-1, save_name=None,
                  use_wavenumber=False):
@@ -474,8 +474,6 @@ class StatisticBase_PSpec2D(object):
 
         Parameters
         ----------
-        show : bool, optional
-            Call `plt.show()` after plotting.
         show_2D : bool, optional
             Plot the 2D power spectrum with contours for the masked regions
             and 2D fit contours (if the 2D power spectrum was fit).
@@ -699,6 +697,3 @@ class StatisticBase_PSpec2D(object):
 
         if save_name is not None:
             plt.savefig(save_name)
-
-        if show:
-            plt.show()

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -507,6 +507,7 @@ class StatisticBase_PSpec2D(object):
         '''
 
         import matplotlib.pyplot as plt
+        from mpl_toolkits.axes_grid1 import make_axes_locatable
 
         if use_wavenumber:
             xlab = r"k / (" + xunit.to_string() + ")"
@@ -516,12 +517,46 @@ class StatisticBase_PSpec2D(object):
         if fit_color is None:
             fit_color = color
 
-        if show_2D:
-            sizes = (16., 6.6)
-        else:
-            sizes = (8., 6.6)
+        fig = plt.gcf()
+        axes = plt.gcf().get_axes()
 
-        fig = plt.figure(figsize=sizes)
+        # Setup axes
+        if len(axes) == 3:
+            # Setup for all 3 axes
+            ax = axes[0]
+            ax_1D = axes[1]
+            ax_1D_res = axes[2]
+        elif len(axes) == 2:
+            if show_2D:
+                ax = axes[0]
+                ax_1D = axes[1]
+            elif show_residual:
+                ax_1D = axes[0]
+                ax_1D_res = axes[1]
+        elif len(axes) == 1:
+            ax_1D = axes[0]
+        else:
+            # If there are none, setup the initial axes
+            if show_2D:
+                ax = plt.subplot2grid((4, 2), (0, 1), colspan=1, rowspan=4)
+
+                if show_residual:
+                    ax_1D = plt.subplot2grid((4, 2), (0, 0), colspan=1,
+                                             rowspan=3)
+                    ax_1D_res = plt.subplot2grid((4, 2), (3, 0), colspan=1,
+                                                 rowspan=1, sharex=ax_1D)
+                else:
+                    ax_1D = plt.subplot2grid((4, 2), (0, 0), colspan=1,
+                                             rowspan=4)
+            else:
+                if show_residual:
+                    ax_1D = plt.subplot2grid((4, 1), (0, 0), colspan=1,
+                                             rowspan=3)
+                    ax_1D_res = plt.subplot2grid((4, 1), (3, 0), colspan=1,
+                                                 rowspan=1, sharex=ax_1D)
+                else:
+                    ax_1D = plt.subplot2grid((4, 1), (0, 0), colspan=1,
+                                             rowspan=4)
 
         # 2D Spectrum is shown alongside 1D. Otherwise only 1D is returned.
         if show_2D:
@@ -536,14 +571,13 @@ class StatisticBase_PSpec2D(object):
             vmax = np.log10(self.ps2D[mask]).max()
             vmin = np.log10(self.ps2D[mask]).min()
 
-            ax = fig.add_axes((0.5, 0.1, 0.4, 0.8))
-
             im1 = ax.imshow(np.log10(self.ps2D), interpolation="nearest",
                             origin="lower", vmax=vmax, vmin=vmin)
 
-            cbaxes = fig.add_axes([0.9, 0.1, 0.03, 0.8])
-            cbar = plt.colorbar(im1, cax=cbaxes)
-            cbar.set_label(r"log $P_2 \ (K_x,\ K_y)$")
+            divider = make_axes_locatable(ax)
+            cax = divider.append_axes("right", "5%", pad="3%")
+            cb = plt.colorbar(im1, cax=cax)
+            cb.set_label(r"log $P_2 \ (K_x,\ K_y)$")
 
             ax.contour(mask, colors=[color], linestyles='--')
 
@@ -553,17 +587,6 @@ class StatisticBase_PSpec2D(object):
 
             if hasattr(self, "_azim_mask"):
                 ax.contour(self._azim_mask, colors=[color], linestyles='--')
-
-        if show_2D:
-            oned_width = 0.4
-        else:
-            oned_width = 0.8
-
-        if show_residual:
-            ax_1D = fig.add_axes((0.1, 0.3, oned_width, 0.6))
-            ax_1D_res = fig.add_axes((0.1, 0.1, oned_width, 0.2))
-        else:
-            ax_1D = fig.add_axes((0.1, 0.1, oned_width, 0.8))
 
         good_interval = clip_func(self.freqs.value, self.low_cut.value,
                                   self.high_cut.value)
@@ -639,7 +662,7 @@ class StatisticBase_PSpec2D(object):
         if show_residual:
             ax_1D_res.set_xlabel("log " + xlab)
 
-            ax_1D.get_xaxis().set_ticks([])
+            # ax_1D.get_xaxis().set_ticks([])
         else:
             ax_1D.set_xlabel("log " + xlab)
 
@@ -669,6 +692,10 @@ class StatisticBase_PSpec2D(object):
             ax_1D_res.grid(True)
 
             ax_1D_res.set_xlim(ax_1D.get_xlim())
+
+        plt.tight_layout()
+
+        fig.subplots_adjust(hspace=0.1)
 
         if save_name is not None:
             plt.savefig(save_name)

--- a/turbustat/statistics/mvc/mvc.py
+++ b/turbustat/statistics/mvc/mvc.py
@@ -385,8 +385,9 @@ class MVC_Distance(object):
                       low_cut=low_cut[1],
                       fit_kwargs={'brk': breaks[1]}, fit_2D=False)
 
-    def distance_metric(self, verbose=False, label1=None, label2=None,
-                        xunit=u.pix**-1, save_name=None,
+    def distance_metric(self, verbose=False, xunit=u.pix**-1,
+                        save_name=None, plot_kwargs1={},
+                        plot_kwargs2={},
                         use_wavenumber=False):
         '''
 
@@ -399,16 +400,17 @@ class MVC_Distance(object):
         ----------
         verbose : bool, optional
             Enables plotting.
-        label1 : str, optional
-            Object or region name for dataset1
-        label2 : str, optional
-            Object or region name for dataset2
-        ang_units : bool, optional
-            Convert frequencies to angular units using the given header.
-        xunit : u.Unit, optional
-            Choose the unit to convert the x-axis to in the plot.
-        save_name : str,optional
-            Save the figure when a file name is given.
+        xunit : `~astropy.units.Unit`, optional
+            Unit of the x-axis in the plot in pixel, angular, or
+            physical units.
+        save_name : str, optional
+            Name of the save file. Enables saving the figure.
+        plot_kwargs1 : dict, optional
+            Pass kwargs to `~turbustat.statistics.MVC.plot_fit`
+            for `data1`.
+        plot_kwargs2 : dict, optional
+            Pass kwargs to `~turbustat.statistics.MVC.plot_fit`
+            for `data2`.
         use_wavenumber : bool, optional
             Plot the x-axis as the wavenumber rather than spatial frequency.
         '''
@@ -423,20 +425,37 @@ class MVC_Distance(object):
             print(self.mvc1.fit.summary())
             print(self.mvc2.fit.summary())
 
-            import matplotlib.pyplot as p
+            import matplotlib.pyplot as plt
 
-            self.mvc1.plot_fit(show=False, color='b', label=label1, symbol='D',
-                               xunit=xunit,
-                               use_wavenumber=use_wavenumber)
-            self.mvc2.plot_fit(show=False, color='g', label=label2, symbol='o',
-                               xunit=xunit,
-                               use_wavenumber=use_wavenumber)
-            p.legend(loc='best')
+            defaults1 = {'color': 'b', 'symbol': 'D', 'label': '1'}
+            defaults2 = {'color': 'g', 'symbol': 'o', 'label': '2'}
+
+            for key in defaults1:
+                if key not in plot_kwargs1:
+                    plot_kwargs1[key] = defaults1[key]
+
+            for key in defaults2:
+                if key not in plot_kwargs2:
+                    plot_kwargs2[key] = defaults2[key]
+
+            if 'xunit' in plot_kwargs1:
+                del plot_kwargs1['xunit']
+            if 'xunit' in plot_kwargs2:
+                del plot_kwargs2['xunit']
+
+            self.mvc1.plot_fit(xunit=xunit,
+                               use_wavenumber=use_wavenumber,
+                               **plot_kwargs1)
+            self.mvc2.plot_fit(xunit=xunit,
+                               use_wavenumber=use_wavenumber,
+                               **plot_kwargs2)
+            axes = plt.gcf().get_axes()
+            axes[0].legend(loc='best', frameon=True)
 
             if save_name is not None:
-                p.savefig(save_name)
-                p.close()
+                plt.savefig(save_name)
+                plt.close()
             else:
-                p.show()
+                plt.show()
 
         return self

--- a/turbustat/statistics/pspec_bispec/bispec.py
+++ b/turbustat/statistics/pspec_bispec/bispec.py
@@ -555,11 +555,16 @@ class Bispectrum_Distance(object):
             raise ValueError("metric must be 'surface' or 'average'.")
 
         if verbose:
-            import matplotlib.pyplot as p
-            p.ion()
+            import matplotlib.pyplot as plt
 
-            fig = p.figure()
-            ax1 = fig.add_subplot(121)
+            fig = plt.gcf()
+
+            if label1 is None:
+                label1 = "1"
+            if label2 is None:
+                label2 = "2"
+
+            ax1 = plt.subplot(121)
             ax1.set_title(label1)
             ax1.imshow(
                 self.bispec1.bicoherence, origin="lower",
@@ -567,25 +572,24 @@ class Bispectrum_Distance(object):
             ax1.set_xlabel(r"$k_1$")
             ax1.set_ylabel(r"$k_2$")
 
-            ax2 = fig.add_subplot(122)
+            ax2 = plt.subplot(122)
             ax2.set_title(label2)
-            im = p.imshow(
+            im = plt.imshow(
                 self.bispec2.bicoherence, origin="lower",
                 interpolation="nearest", vmax=1.0, vmin=0.0)
             ax2.set_xlabel(r"$k_1$")
-            # ax2.set_ylabel(r"$k_2$")
             ax2.set_yticklabels([])
 
             fig.subplots_adjust(right=0.8)
             cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])
             fig.colorbar(im, cax=cbar_ax)
 
-            # p.tight_layout()
+            # plt.tight_layout()
             if save_name is not None:
-                p.savefig(save_name)
-                p.close()
+                plt.savefig(save_name)
+                plt.close()
             else:
-                p.show()
+                plt.show()
 
         return self
 

--- a/turbustat/statistics/pspec_bispec/pspec.py
+++ b/turbustat/statistics/pspec_bispec/pspec.py
@@ -280,8 +280,9 @@ class PSpec_Distance(object):
         self.results = None
         self.distance = None
 
-    def distance_metric(self, verbose=False, label1=None, label2=None,
-                        xunit=u.pix**-1, save_name=None,
+    def distance_metric(self, verbose=False, xunit=u.pix**-1,
+                        save_name=None, plot_kwargs1={},
+                        plot_kwargs2={},
                         use_wavenumber=False):
         '''
 
@@ -294,14 +295,17 @@ class PSpec_Distance(object):
         ----------
         verbose : bool, optional
             Enables plotting.
-        label1 : str, optional
-            Object or region name for data1
-        label2 : str, optional
-            Object or region name for data2
-        xunit : u.Unit, optional
-            Choose the unit to convert the x-axis to in the plot.
-        save_name : str,optional
-            Save the figure when a file name is given.
+        xunit : `~astropy.units.Unit`, optional
+            Unit of the x-axis in the plot in pixel, angular, or
+            physical units.
+        save_name : str, optional
+            Name of the save file. Enables saving the figure.
+        plot_kwargs1 : dict, optional
+            Pass kwargs to `~turbustat.statistics.PowerSpectrum.plot_fit`
+            for `data1`.
+        plot_kwargs2 : dict, optional
+            Pass kwargs to `~turbustat.statistics.PowerSpectrum.plot_fit`
+            for `data2`.
         use_wavenumber : bool, optional
             Plot the x-axis as the wavenumber rather than spatial frequency.
         '''
@@ -315,22 +319,37 @@ class PSpec_Distance(object):
             print(self.pspec1.fit.summary())
             print(self.pspec2.fit.summary())
 
-            import matplotlib.pyplot as p
+            import matplotlib.pyplot as plt
 
-            self.pspec1.plot_fit(show=False, color='b',
-                                 label=label1, symbol='D',
-                                 xunit=xunit,
-                                 use_wavenumber=use_wavenumber)
-            self.pspec2.plot_fit(show=False, color='g',
-                                 label=label2, symbol='o',
-                                 xunit=xunit,
-                                 use_wavenumber=use_wavenumber)
-            p.legend(loc='best')
+            defaults1 = {'color': 'b', 'symbol': 'D', 'label': '1'}
+            defaults2 = {'color': 'g', 'symbol': 'o', 'label': '2'}
+
+            for key in defaults1:
+                if key not in plot_kwargs1:
+                    plot_kwargs1[key] = defaults1[key]
+
+            for key in defaults2:
+                if key not in plot_kwargs2:
+                    plot_kwargs2[key] = defaults2[key]
+
+            if 'xunit' in plot_kwargs1:
+                del plot_kwargs1['xunit']
+            if 'xunit' in plot_kwargs2:
+                del plot_kwargs2['xunit']
+
+            self.pspec1.plot_fit(xunit=xunit,
+                                 use_wavenumber=use_wavenumber,
+                                 **plot_kwargs1)
+            self.pspec2.plot_fit(xunit=xunit,
+                                 use_wavenumber=use_wavenumber,
+                                 **plot_kwargs2)
+            axes = plt.gcf().get_axes()
+            axes[0].legend(loc='best', frameon=True)
 
             if save_name is not None:
-                p.savefig(save_name)
-                p.close()
+                plt.savefig(save_name)
+                plt.close()
             else:
-                p.show()
+                plt.show()
 
         return self

--- a/turbustat/statistics/scf/scf.py
+++ b/turbustat/statistics/scf/scf.py
@@ -583,11 +583,6 @@ class SCF(BaseStatisticMixIn):
         import matplotlib.pyplot as plt
         from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-        if show_surface and show_radial:
-            fig = plt.figure(figsize=(8.9, 4.8))
-        else:
-            fig = plt.figure(figsize=(6.4, 4.8))
-
         fig = plt.gcf()
         axes = plt.gcf().get_axes()
         if len(axes) == 3:

--- a/turbustat/statistics/vca_vcs/vca.py
+++ b/turbustat/statistics/vca_vcs/vca.py
@@ -282,8 +282,9 @@ class VCA_Distance(object):
                       radial_pspec_kwargs={'logspacing': logspacing},
                       fit_2D=False)
 
-    def distance_metric(self, verbose=False, label1=None, label2=None,
-                        xunit=u.pix**-1, save_name=None,
+    def distance_metric(self, verbose=False, xunit=u.pix**-1,
+                        save_name=None, plot_kwargs1={},
+                        plot_kwargs2={},
                         use_wavenumber=False):
         '''
 
@@ -295,16 +296,17 @@ class VCA_Distance(object):
         ----------
         verbose : bool, optional
             Enables plotting.
-        label1 : str, optional
-            Object or region name for cube1
-        label2 : str, optional
-            Object or region name for cube2
-        ang_units : bool, optional
-            Convert frequencies to angular units using the given header.
-        xunit : u.Unit, optional
-            Choose the unit to convert the x-axis to in the plot.
-        save_name : str,optional
-            Save the figure when a file name is given.
+        xunit : `~astropy.units.Unit`, optional
+            Unit of the x-axis in the plot in pixel, angular, or
+            physical units.
+        save_name : str, optional
+            Name of the save file. Enables saving the figure.
+        plot_kwargs1 : dict, optional
+            Pass kwargs to `~turbustat.statistics.VCA.plot_fit`
+            for `data1`.
+        plot_kwargs2 : dict, optional
+            Pass kwargs to `~turbustat.statistics.VCA.plot_fit`
+            for `data2`.
         use_wavenumber : bool, optional
             Plot the x-axis as the wavenumber rather than spatial frequency.
         '''
@@ -317,24 +319,39 @@ class VCA_Distance(object):
 
         if verbose:
 
-            print("Fit to %s" % (label1))
             print(self.vca1.fit.summary())
-            print("Fit to %s" % (label2))
             print(self.vca2.fit.summary())
 
-            import matplotlib.pyplot as p
+            import matplotlib.pyplot as plt
 
-            self.vca1.plot_fit(show=False, color='b', label=label1, symbol='D',
-                               xunit=xunit,
-                               use_wavenumber=use_wavenumber)
-            self.vca2.plot_fit(show=False, color='g', label=label2, symbol='o',
-                               xunit=xunit,
-                               use_wavenumber=use_wavenumber)
-            p.legend(loc='upper right')
+            defaults1 = {'color': 'b', 'symbol': 'D', 'label': '1'}
+            defaults2 = {'color': 'g', 'symbol': 'o', 'label': '2'}
+
+            for key in defaults1:
+                if key not in plot_kwargs1:
+                    plot_kwargs1[key] = defaults1[key]
+
+            for key in defaults2:
+                if key not in plot_kwargs2:
+                    plot_kwargs2[key] = defaults2[key]
+
+            if 'xunit' in plot_kwargs1:
+                del plot_kwargs1['xunit']
+            if 'xunit' in plot_kwargs2:
+                del plot_kwargs2['xunit']
+
+            self.vca1.plot_fit(xunit=xunit,
+                               use_wavenumber=use_wavenumber,
+                               **plot_kwargs1)
+            self.vca2.plot_fit(xunit=xunit,
+                               use_wavenumber=use_wavenumber,
+                               **plot_kwargs2)
+            axes = plt.gcf().get_axes()
+            axes[0].legend(loc='best', frameon=True)
 
             if save_name is not None:
-                p.savefig(save_name)
-                p.close()
+                plt.savefig(save_name)
+                plt.close()
             else:
-                p.show()
+                plt.show()
         return self

--- a/turbustat/statistics/wavelets/wavelet_transform.py
+++ b/turbustat/statistics/wavelets/wavelet_transform.py
@@ -443,15 +443,22 @@ class Wavelet(BaseStatisticMixIn):
         if fit_color is None:
             fit_color = color
 
-        fig = plt.figure()
-
-        if show_residual:
-            ax = plt.subplot2grid((4, 1), (0, 0), colspan=1, rowspan=3)
-            ax_r = plt.subplot2grid((4, 1), (3, 0), colspan=1,
-                                    rowspan=1,
-                                    sharex=ax)
+        # Check for already existing subplots
+        fig = plt.gcf()
+        axes = plt.gcf().get_axes()
+        if len(axes) == 0:
+            if show_residual:
+                ax = plt.subplot2grid((4, 1), (0, 0), colspan=1, rowspan=3)
+                ax_r = plt.subplot2grid((4, 1), (3, 0), colspan=1,
+                                        rowspan=1,
+                                        sharex=ax)
+            else:
+                ax = plt.subplot(111)
+        elif len(axes) == 1:
+            ax = axes[0]
         else:
-            ax = plt.subplot(111)
+            ax = axes[0]
+            ax_r = axes[1]
 
         ax.set_xscale("log")
         ax.set_yscale("log")
@@ -623,9 +630,9 @@ class Wavelet_Distance(object):
         self.wt2 = Wavelet(dataset2, scales=scales)
         self.wt2.run(xlow=xlow[1], xhigh=xhigh[1])
 
-    def distance_metric(self, verbose=False, label1=None,
-                        label2=None, xunit=u.deg,
-                        save_name=None):
+    def distance_metric(self, verbose=False, xunit=u.deg,
+                        save_name=None, plot_kwargs1={},
+                        plot_kwargs2={}):
         '''
         Implements the distance metric for 2 wavelet transforms.
         We fit the linear portion of the transform to represent the powerlaw
@@ -634,16 +641,17 @@ class Wavelet_Distance(object):
         ----------
         verbose : bool, optional
             Enables plotting.
-        label1 : str, optional
-            Object or region name for dataset1
-        label2 : str, optional
-            Object or region name for dataset2
-        ang_units : bool, optional
-            Convert frequencies to angular units using the given header.
-        unit : u.Unit, optional
-            Choose the angular unit to convert to when ang_units is enabled.
-        save_name : str,optional
-            Save the figure when a file name is given.
+        xunit : `~astropy.units.Unit`, optional
+            Unit of the x-axis in the plot in pixel, angular, or
+            physical units.
+        save_name : str, optional
+            Name of the save file. Enables saving the figure.
+        plot_kwargs1 : dict, optional
+            Pass kwargs to `~turbustat.statistics.Wavelet.plot_transform` for
+            `dataset1`.
+        plot_kwargs2 : dict, optional
+            Pass kwargs to `~turbustat.statistics.Wavelet.plot_transform` for
+            `dataset2`.
         '''
 
         # Construct t-statistic
@@ -659,10 +667,26 @@ class Wavelet_Distance(object):
 
             import matplotlib.pyplot as plt
 
-            self.wt1.plot_transform(xunit=xunit, show=False,
-                                    color='b', symbol='D', label=label1)
-            self.wt2.plot_transform(xunit=xunit, show=False,
-                                    color='g', symbol='o', label=label1)
+            defaults1 = {'color': 'b', 'symbol': 'D', 'label': '1'}
+            defaults2 = {'color': 'g', 'symbol': 'o', 'label': '2'}
+
+            for key in defaults1:
+                if key not in plot_kwargs1:
+                    plot_kwargs1[key] = defaults1[key]
+
+            for key in defaults2:
+                if key not in plot_kwargs2:
+                    plot_kwargs2[key] = defaults2[key]
+
+            if 'xunit' in plot_kwargs1:
+                del plot_kwargs1['xunit']
+            if 'xunit' in plot_kwargs2:
+                del plot_kwargs2['xunit']
+
+            self.wt1.plot_transform(xunit=xunit,
+                                    **plot_kwargs1)
+            self.wt2.plot_transform(xunit=xunit,
+                                    **plot_kwargs2)
             plt.legend(loc='best')
 
             if save_name is not None:

--- a/turbustat/statistics/wavelets/wavelet_transform.py
+++ b/turbustat/statistics/wavelets/wavelet_transform.py
@@ -630,7 +630,7 @@ class Wavelet_Distance(object):
         self.wt2 = Wavelet(dataset2, scales=scales)
         self.wt2.run(xlow=xlow[1], xhigh=xhigh[1])
 
-    def distance_metric(self, verbose=False, xunit=u.deg,
+    def distance_metric(self, verbose=False, xunit=u.pix,
                         save_name=None, plot_kwargs1={},
                         plot_kwargs2={}):
         '''
@@ -687,7 +687,8 @@ class Wavelet_Distance(object):
                                     **plot_kwargs1)
             self.wt2.plot_transform(xunit=xunit,
                                     **plot_kwargs2)
-            plt.legend(loc='best')
+            axes = plt.gcf().get_axes()
+            axes[0].legend(loc='best', frameon=True)
 
             if save_name is not None:
                 plt.savefig(save_name)


### PR DESCRIPTION
Some of the plot changes from #191 broke the plotting in the distance metrics that were using the plotting routine from the statistic to overlay on the same axes. The statistics that create a new figure for the plot now grab the existing figure (if it exists) to overlay on the same axes.