### PR TITLE
PCA: catch fitting failures; alter correction factor

### DIFF
--- a/turbustat/statistics/pca/width_estimate.py
+++ b/turbustat/statistics/pca/width_estimate.py
@@ -370,14 +370,17 @@ def fit_2D_ellipse(pts, **bootstrap_kwargs):
     '''
 
     ellip = EllipseModel()
-    ellip.estimate(pts)
-    ellip.estimate_stderrs(pts, **bootstrap_kwargs)
+    try:
+        ellip.estimate(pts)
+        ellip.estimate_stderrs(pts, **bootstrap_kwargs)
 
-    xwidth = ellip.params[2] / np.sqrt(2)
-    ywidth = ellip.params[3] / np.sqrt(2)
+        xwidth = ellip.params[2] / np.sqrt(2)
+        ywidth = ellip.params[3] / np.sqrt(2)
 
-    xwidth_err = ellip.param_errs[2] / np.sqrt(2)
-    ywidth_err = ellip.param_errs[3] / np.sqrt(2)
+        xwidth_err = ellip.param_errs[2] / np.sqrt(2)
+        ywidth_err = ellip.param_errs[3] / np.sqrt(2)
+    except ValueError:
+        ywidth = xwidth = ywidth_err = xwidth_err = np.NaN
 
     return ywidth, xwidth, ywidth_err, xwidth_err, ellip
 

--- a/turbustat/statistics/pca/width_estimate.py
+++ b/turbustat/statistics/pca/width_estimate.py
@@ -224,7 +224,8 @@ def WidthEstimate2D(inList, method='contour', noise_ACF=0,
         # We need the number of pixels across 1 FWHM
         # Since it's just being used in the formula below, I don't
         # think rounding to the nearest int is needed.
-        pix_per_beam = beam_fwhm.value / spatial_cdelt.value
+        pix_per_beam = beam_fwhm.value / spatial_cdelt.value / \
+            np.sqrt(8 * np.log(2)) / np.sqrt(2)
 
         # Using the definition from Chris Brunt's thesis for a gaussian
         # beam. Note that the IDL code has:
@@ -233,7 +234,10 @@ def WidthEstimate2D(inList, method='contour', noise_ACF=0,
         # deltaz[i]=(p[i,1]^kappa-(e*1.0)^kappa)^(1./kappa)
         # I think the (e * 1.0) term is where the beam size should be
         # used, which is what is used here.
-        kappa = 0.8
+
+        # For an exponential ACF
+        kappa = 1.
+
         e = np.power(3. / ((kappa + 2.) * (kappa + 3.)), 1 / kappa)
         # This is the other form that appears in the thesis.
         # e = 0.65 + 0.1 * kappa

--- a/turbustat/statistics/stats_utils.py
+++ b/turbustat/statistics/stats_utils.py
@@ -423,6 +423,9 @@ class EllipseModel(object):
         if not hasattr(self, "params"):
             raise AttributeError("Run EllipseModel.estimate first.")
 
+        if self.params is None:
+            raise ValueError("No parameters set. Run fit first.")
+
         if alpha < 0 or alpha >= 1.:
             raise ValueError("alpha must be between 0 and 1.")
 

--- a/turbustat/tests/test_pca.py
+++ b/turbustat/tests/test_pca.py
@@ -48,8 +48,8 @@ def test_PCA_method():
                    tester.intercept_error_range(unit=u.pix)[0].value,
                    tester.intercept_error_range(unit=u.pix)[1].value)
     assert_between(fit_values["sonic_length"],
-                   tester.sonic_length()[1][0].value,
-                   tester.sonic_length()[1][1].value)
+                   tester.sonic_length(use_gamma=False)[1][0].value,
+                   tester.sonic_length(use_gamma=False)[1][1].value)
 
     # Test loading and saving
     tester.save_results("pca_output.pkl", keep_data=False)
@@ -76,8 +76,8 @@ def test_PCA_method():
                    saved_tester.intercept_error_range(unit=u.pix)[0].value,
                    saved_tester.intercept_error_range(unit=u.pix)[1].value)
     assert_between(fit_values["sonic_length"],
-                   saved_tester.sonic_length()[1][0].value,
-                   saved_tester.sonic_length()[1][1].value)
+                   saved_tester.sonic_length(use_gamma=False)[1][0].value,
+                   saved_tester.sonic_length(use_gamma=False)[1][1].value)
 
 
 @pytest.mark.skipif("not EMCEE_INSTALLED")
@@ -107,8 +107,8 @@ def test_PCA_method_w_bayes():
                    tester.intercept_error_range(unit=u.pix)[0].value,
                    tester.intercept_error_range(unit=u.pix)[1].value)
     assert_between(fit_values["sonic_length_bayes"],
-                   tester.sonic_length()[1][0].value,
-                   tester.sonic_length()[1][1].value)
+                   tester.sonic_length(use_gamma=False)[1][0].value,
+                   tester.sonic_length(use_gamma=False)[1][1].value)
 
 
 @pytest.mark.parametrize("method", ['odr', 'bayes'])
@@ -132,7 +132,7 @@ def test_PCA_fitting(method):
 
     npt.assert_allclose(tester.index, index, atol=0.05)
     npt.assert_allclose(tester.intercept(unit=u.pix).value, 1, atol=0.05)
-    npt.assert_allclose(tester.gamma, (index - 0.03) / 1.07, atol=0.05)
+    npt.assert_allclose(tester.gamma, 1.52 * index - 0.19, atol=0.05)
 
     # Check the sonic length
     T_k = 10 * u.K

--- a/turbustat/tests/test_pca.py
+++ b/turbustat/tests/test_pca.py
@@ -199,17 +199,19 @@ def test_spatial_with_beam():
     Test running the spatial width find with beam corrections enabled.
     '''
 
-    model_gauss = generate_2D_array(x_std=10, y_std=10)
+    conv_scale = np.sqrt(10**2 + (4 / 2.35)**2)
+
+    model_gauss = generate_2D_array(x_std=conv_scale, y_std=conv_scale)
 
     model_gauss = model_gauss[np.newaxis, :]
 
     widths, errors = WidthEstimate2D(model_gauss, method='contour',
-                                     brunt_beamcorrect=False,
+                                     brunt_beamcorrect=True,
                                      beam_fwhm=2.0 * u.deg,
                                      spatial_cdelt=0.5 * u.deg)
 
     # Using value based on run with given settings.
-    npt.assert_approx_equal(widths[0], 7.071, significant=4)
+    npt.assert_approx_equal(widths[0], 6.749, significant=4)
 
 
 @pytest.mark.parametrize(('method'), ('fit', 'interpolate', 'walk-down'))


### PR DESCRIPTION
* Catch fit failures to the contour for the spatial scales
* Change the correction factor of the PCA fit index to Eq. 4.1 from Brunt & Heyer 2002