### PR TITLE
Delta-variance: Revise astropy convolution wrapper

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -10,7 +10,6 @@ dependencies:
     - matplotlib
     - numpy
     - scipy
-    - pandas
     - statsmodels
     - scikit-learn
     - scikit-image

--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 Version 1.0 (unreleased)
 ------------------------
+* #208 - Fix #207; description of NaN handling for the delta-variance tutorial from @keflavich. **Change to requiring astropy >v2!**
 * #171 - Expand PCA tutorial; fix unit conversion error in astropy 3.2dev
 * #170 - Add tutorial pages for distance metrics and updated distance metric inputs. **API CHANGES IN DISTANCE METRICS!**
 * #192 - Add stddev and weighted fitting for `Wavelet`. Correct bug in fitting weights for `StatisticBase_PSpec2D`.

--- a/README.md
+++ b/README.md
@@ -49,12 +49,11 @@ Package Dependencies
 
 Requires:
 
- *   astropy>=1.0
+ *   astropy>=2.0
  *   numpy>=1.7
  *   matplotlib>=1.2
  *   scipy>=0.12
  *   sklearn>=0.13.0
- *   pandas>=0.13
  *   statsmodels>=0.4.0
  *   scikit-image>=0.12
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ MOCK_MODULES = ['sklearn', 'sklearn.metrics', 'sklearn.metrics.pairwise',
                 'statsmodels.formula', 'statsmodels.distributions',
                 'statsmodels.distributions.empirical_distribution',
                 'statsmodels.base', 'statsmodels.base.model',
-                'astrodendro', 'signal_id', 'pandas',
+                'astrodendro', 'signal_id'
                 'spectral_cube', 'spectral_cube._moments',
                 'spectral_cube.wcs_utils', "spectral_cube.cube_utils",
                 'spectral_cube.lower_dimensional_structures',

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,12 +6,11 @@ TurbuStat is currently only available from the `github repo <https://github.com/
 
 TurbuStat requires the follow packages:
 
- *   astropy>=1.0
+ *   astropy>=2.0
  *   numpy>=1.7
  *   matplotlib>=1.2
  *   scipy>=0.12
  *   sklearn>=0.13.0
- *   pandas>=0.13
  *   statsmodels>=0.4.0
  *   scikit-image>=0.12
 

--- a/docs/tutorials/statistics/delta_variance_example.rst
+++ b/docs/tutorials/statistics/delta_variance_example.rst
@@ -138,7 +138,11 @@ The entire process is performed through `~turbustat.statistics.DeltaVariance.run
 
 Since the Delta-variance is based on a series of convolutions, there is a choice for how the boundaries should be treated. This is set by the `boundary` keyword in `~turbustat.statistics.DeltaVariance.run`. By default, `boundary='wrap'` as is appropriate for simulated data in a periodic box. If the data is *not* periodic in the spatial dimensions, `boundary='fill'` should be used. This mode pads the edges of the data based on the size of the convolution kernel used.
 
-Another important keyword is `nan_interpolate`. By default, the convolution will interpolate over NaNs, which works well if the NaNs are small regions dispersed throughout the image. However, if your data have a large border of NaNs around the data, as is common for observational data, interpolating over NaNs will lead to edge effects and large deviations from the data at small lag values. If you find a non-smooth delta-variance curve with large spikes, try setting `nan_interpolate=False`.
+When an image contains NaNs, there are two important parameters for the convolution: `preserve_nan` and `nan_treatment`. Setting `preserve_nan=True` will set pixels that were originally a NaN to a NaN in the convolved image.  This is useful for when the image has a border of NaNs. When the edges are not handled correctly, the delta-variance curve will have large spikes at small lag values.
+
+If an image has missing values within the image, setting `nan_treatment='interpolate'` will interpolate over the missing regions, providing a smoothed version of the convolved image.
+
+If an image has both missing regions and a border of NaNs, manual treatment may be necessary to convert the edges to NaNs while correctly handling the interpolating regions in the interior. See the `convolution <http://docs.astropy.org/en/stable/api/astropy.convolution.convolve_fft.html#astropy.convolution.convolve_fft>`_ page on astropy for more information.
 
 Similar to the fitting for other statistics, the Delta-variance curve can be fit with a segmented linear model:
 
@@ -179,9 +183,7 @@ There will now be two slopes, and a break point returned:
     >>> delvar.brk  # doctest: +SKIP
     <Quantity 19.413294229328802 pix>
 
-.. warning:: The turn-over at large scales tends to be dominated by the kernel shape rather than the data. Further, there are variations on those large scales that depend on how the convolution is done (there are some difference between v1 and v2 of astropy).
-
-On scales smaller than 4 pixels, the curve may tend to steepen. This is due to the finite beam-size (for observational data; see `Bensch et al. 2001. <https://ui.adsabs.harvard.edu/#abs/2001A&A...366..636B/abstract>`_).
+.. warning:: The turn-over at large scales (usually larger than half the image size) tends to be dominated by the kernel shape rather than the data.  On scales smaller than the beam size, the curve will tend to steepen.  This is due to the enhanced correlations from over-sampling the beam, which is standard for radio and submillimetre observational data. See `Bensch et al. 2001. <https://ui.adsabs.harvard.edu/#abs/2001A&A...366..636B/abstract>`_ for a discussion of how the beam affects the delta-variance curves.
 
 Volker Ossenkopf-Okada's IDL Delta-Variance codes is available `here <https://hera.ph1.uni-koeln.de/~ossk/Myself/deltavariance.html>`__.
 

--- a/setup.py
+++ b/setup.py
@@ -39,16 +39,6 @@ def check_dependencies():
             "Install or upgrade scipy before installing TurbuStat.")
 
     try:
-        import pandas
-        pa_version = pandas.__version__
-        if parse_version(pa_version) < parse_version('0.13'):
-            print("***Before installing, upgrade pandas to 0.13***")
-            raise ImportError
-    except:
-        raise ImportError(
-            "Install or upgrade pandas before installing TurbuStat.")
-
-    try:
         from statsmodels.version import version as sm_version
         if parse_version(sm_version) < parse_version('0.4.0'):
             print("***Before installing, upgrade statsmodels to 0.4.0***")
@@ -70,18 +60,19 @@ def check_dependencies():
     try:
         import astrodendro
     except:
-        Warning("Install or upgrade astrodendro to use the dendrogram"
-                 " statistics in TurbuStat. ***NOTE: Need dev version as"
-                 "of 17/06/14.***")
+        raise ImportError("Install or upgrade astrodendro to use the"
+                          " dendrogram statistics in TurbuStat. "
+                          "***NOTE: Need dev version as "
+                          "of 17/06/14.***")
     try:
         import spectral_cube
     except ImportError:
         raise ImportError("Install spectral-cube before installing TurbuStat")
 
-    try:
-        import signal_id
-    except ImportError:
-        Warning("signal-id is an optional package for TurbuStat.")
+    # try:
+    #     import signal_id
+    # except ImportError:
+    #     Warning("signal-id is an optional package for TurbuStat.")
 
 
 if __name__ == "__main__":

--- a/turbustat/statistics/convolve_wrapper.py
+++ b/turbustat/statistics/convolve_wrapper.py
@@ -54,31 +54,23 @@ def convolution_wrapper(img, kernel, use_pyfftw=False, threads=1,
         use_ifftn = np.fft.ifftn
 
     if int(astro_version[0]) >= 2:
-        if kwargs.get("nan_interpolate") is not None:
-            if kwargs['nan_interpolate']:
-                nan_treatment = 'interpolate'
-            else:
-                nan_treatment = 'fill'
-            kwargs.pop('nan_interpolate')
-        else:
-            # Default to not nan interpolating
-            nan_treatment = 'fill'
 
         conv_img = convolve_fft(img, kernel, normalize_kernel=True,
-                                nan_treatment=nan_treatment,
-                                preserve_nan=False,
                                 fftn=use_fftn,
                                 ifftn=use_ifftn,
                                 **kwargs)
+
     else:
+        raise Exception("Delta-variance requires astropy version >2.")
+
         # in astropy >= v2, fill_value can be a NaN. ignore_edge_zeros gives
         # the same behaviour in older versions.
-        if kwargs.get('fill_value'):
-            kwargs.pop('fill_value')
-        conv_img = convolve_fft(img, kernel, normalize_kernel=True,
-                                ignore_edge_zeros=True,
-                                fftn=use_fftn,
-                                ifftn=use_ifftn,
-                                **kwargs)
+        # if kwargs.get('fill_value'):
+        #     kwargs.pop('fill_value')
+        # conv_img = convolve_fft(img, kernel, normalize_kernel=True,
+        #                         ignore_edge_zeros=True,
+        #                         fftn=use_fftn,
+        #                         ifftn=use_ifftn,
+        #                         **kwargs)
 
     return conv_img

--- a/turbustat/statistics/delta_variance/delta_variance.py
+++ b/turbustat/statistics/delta_variance/delta_variance.py
@@ -74,10 +74,6 @@ class DeltaVariance(BaseStatisticMixIn):
         if distance is not None:
             self.distance = distance
 
-        self.nanflag = False
-        if np.isnan(self.data).any() or np.isnan(self.weights).any():
-            self.nanflag = True
-
         if lags is None:
             min_size = 3.0
             self.lags = \
@@ -140,7 +136,8 @@ class DeltaVariance(BaseStatisticMixIn):
         self._weights = arr
 
     def do_convolutions(self, allow_huge=False, boundary='wrap',
-                        min_weight_frac=0.01, nan_interpolate=True,
+                        min_weight_frac=0.01, nan_treatment=False,
+                        preserve_nan=False,
                         use_pyfftw=False, threads=1,
                         pyfftw_kwargs={},
                         show_progress=True):
@@ -160,7 +157,7 @@ class DeltaVariance(BaseStatisticMixIn):
             not guaranteed to! Increase this value if artifacts are
             encountered (this typically results in large spikes in the
             delta-variance curve).
-        nan_interpolate : bool, optional
+        nan_treatment : bool, optional
             Enable to interpolate over NaNs in the convolution. Default is
             True.
         use_pyfftw : bool, optional
@@ -199,7 +196,7 @@ class DeltaVariance(BaseStatisticMixIn):
                 convolution_wrapper(pad_img, core, boundary=boundary,
                                     fill_value=np.NaN,
                                     allow_huge=allow_huge,
-                                    nan_interpolate=nan_interpolate,
+                                    nan_treatment=nan_treatment,
                                     use_pyfftw=use_pyfftw,
                                     threads=threads,
                                     pyfftw_kwargs=pyfftw_kwargs)
@@ -207,7 +204,7 @@ class DeltaVariance(BaseStatisticMixIn):
                 convolution_wrapper(pad_img, annulus,
                                     boundary=boundary, fill_value=np.NaN,
                                     allow_huge=allow_huge,
-                                    nan_interpolate=nan_interpolate,
+                                    nan_treatment=nan_treatment,
                                     use_pyfftw=use_pyfftw,
                                     threads=threads,
                                     pyfftw_kwargs=pyfftw_kwargs)
@@ -215,7 +212,7 @@ class DeltaVariance(BaseStatisticMixIn):
                 convolution_wrapper(pad_weights, core,
                                     boundary=boundary, fill_value=np.NaN,
                                     allow_huge=allow_huge,
-                                    nan_interpolate=nan_interpolate,
+                                    nan_treatment=nan_treatment,
                                     use_pyfftw=use_pyfftw,
                                     threads=threads,
                                     pyfftw_kwargs=pyfftw_kwargs)
@@ -223,7 +220,7 @@ class DeltaVariance(BaseStatisticMixIn):
                 convolution_wrapper(pad_weights, annulus,
                                     boundary=boundary, fill_value=np.NaN,
                                     allow_huge=allow_huge,
-                                    nan_interpolate=nan_interpolate,
+                                    nan_treatment=nan_treatment,
                                     use_pyfftw=use_pyfftw,
                                     threads=threads,
                                     pyfftw_kwargs=pyfftw_kwargs)
@@ -589,7 +586,8 @@ class DeltaVariance(BaseStatisticMixIn):
             plt.show()
 
     def run(self, show_progress=True, verbose=False, xunit=u.pix,
-            nan_interpolate=True, allow_huge=False, boundary='wrap',
+            nan_treatment='interpolate', preserve_nan=False,
+            allow_huge=False, boundary='wrap',
             use_pyfftw=False, threads=1, pyfftw_kwargs={},
             xlow=None, xhigh=None,
             brk=None, fit_kwargs={},
@@ -607,7 +605,7 @@ class DeltaVariance(BaseStatisticMixIn):
             The unit to show the x-axis in.
         allow_huge : bool, optional
             See `~DeltaVariance.do_convolutions`.
-        nan_interpolate : bool, optional
+        nan_treatment : bool, optional
             Enable to interpolate over NaNs in the convolution. Default is
             True.
         boundary : {"wrap", "fill"}, optional
@@ -634,7 +632,8 @@ class DeltaVariance(BaseStatisticMixIn):
         '''
 
         self.do_convolutions(allow_huge=allow_huge, boundary=boundary,
-                             nan_interpolate=nan_interpolate,
+                             nan_treatment=nan_treatment,
+                             preserve_nan=preserve_nan,
                              use_pyfftw=use_pyfftw,
                              threads=threads,
                              pyfftw_kwargs=pyfftw_kwargs,


### PR DESCRIPTION
Fixing part of #207.

1. Require astropy >v2 to use the current  `convolve_fft` API.
2. Revise recommendations for NaN convolution settings, as recommended by @keflavich in #207.
3. Removed listing pandas as a dependency (#203).