### PR TITLE
Allow distance metrics to take Stats classes as inputs

### DIFF
--- a/docs/statistics.rst
+++ b/docs/statistics.rst
@@ -2,12 +2,12 @@
 Statistics
 ==========
 
-Along with acting as the base classes for the distance metrics, the statistics can also return useful information about single datasets.  See the :ref:`runmetrics` tutorial for more information on how to use Distance Metrics.
+Along with acting as the base classes for the distance metrics, the statistics can also return useful information about single datasets.  See the :ref:`runstats` tutorial for more information on computing Statistics.
 
 Distance Metrics
 ================
 
-The distance metrics are computed using certain outputs contained in the related statistics class.
+The distance metrics are computed using certain outputs contained in the related statistics class.  See the :ref:`runmetrics` tutorial for more information on how to use Distance Metrics.
 
 Nearly all of the distance metrics are actually `"pseudo" - distance metrics <https://en.wikipedia.org/wiki/Pseudometric_space>`_. They must have the following properties:
 

--- a/docs/statistics.rst
+++ b/docs/statistics.rst
@@ -2,7 +2,7 @@
 Statistics
 ==========
 
-Along with acting as the base classes for the distance metrics, the statistics can also return useful information about single datasets.
+Along with acting as the base classes for the distance metrics, the statistics can also return useful information about single datasets.  See the :ref:`runmetrics` tutorial for more information on how to use Distance Metrics.
 
 Distance Metrics
 ================

--- a/docs/tutorials/applying_apodizing_functions.rst
+++ b/docs/tutorials/applying_apodizing_functions.rst
@@ -6,7 +6,7 @@ Applying Apodizing Kernels to Data
 
 Applying Fourier transforms to images with emission at the edges can lead to severe ringing effects from the `Gibbs phenomenon <https://en.wikipedia.org/wiki/Gibbs_phenomenon>`_.  This can be an issue for all spatial power-spectra, including the :ref:`PowerSpectrum <pspec_tutorial>`, :ref:`VCA <vca_tutorial>`, and :ref:`MVC <mvc_tutorial>`.
 
-A common way to avoid this issue is to apply a window function that smoothly tapers the values at the edges of the image to zero (e.g., ` Stanimirovic et al. 1999 <https://ui.adsabs.harvard.edu/#abs/1999MNRAS.302..417S/abstract>`_).  However, the shape of the window function will also affect some frequencies in the Fourier transform. This page demonstrates these effects for some common window shapes.
+A common way to avoid this issue is to apply a window function that smoothly tapers the values at the edges of the image to zero (e.g., `Stanimirovic et al. 1999 <https://ui.adsabs.harvard.edu/#abs/1999MNRAS.302..417S/abstract>`_).  However, the shape of the window function will also affect some frequencies in the Fourier transform. This page demonstrates these effects for some common window shapes.
 
 TurbuStat has four built-in apodizing functions based on the implementations from `photutils <https://photutils.readthedocs.io/en/stable/psf_matching.html>`_:
 

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -21,6 +21,7 @@ Statistics
 .. toctree::
     :maxdepth: 2
 
+    statistics/running_statistics
     statistics/bispectrum_example
     statistics/delta_variance_example
     statistics/dendrogram_example
@@ -48,6 +49,7 @@ A distance metric for **Tsallis** statistics has not been explored and is not cu
 .. toctree::
     :maxdepth: 2
 
+    metrics/running_metrics
     metrics/bispectrum_example
     metrics/cramer_example
     metrics/delvar_example

--- a/docs/tutorials/metrics/bispectrum_example.rst
+++ b/docs/tutorials/metrics/bispectrum_example.rst
@@ -68,15 +68,7 @@ The distances between these images are:
     >>> bispec.mean_distance  # doctest: +SKIP
     0.009241794373870557
 
-If a `~turbustat.statistics.Bispectrum` has been previously defined, it can be passed to `~turbustat.statistics.Bispectrum_Distance` without recomputing by passing it as `fiducial_model`:
-
-    >>> from turbustat.statistics import Bispectrum  # doctest: +SKIP
-    >>> bispec_moment0 = Bispectrum(moment0_fid).run()  # doctest: +SKIP
-    >>> bispec = Bispectrum_Distance(moment0_fid, moment0, fiducial_model=bispec_moment0)  # doctest: +SKIP
-
-`fiducial_model` will be set to `~turbustat.statistics.Bispectrum_Distance.bispec1`. This is useful when comparing a number of images to a common (i.e., fiducial) image. Note that the data (`moment0`) must still be passed.
-
-.. warning:: Caution must be used when passing `fiducial_model` as there are no checks to ensure the bispectra were computed the same way (e.g., do both have `mean_sub=True` set?). Ensure that the keyword arguments for `fiducial_model` match those specified to `~turbustat.statistics.Bispectrum_Distance`.
+.. warning:: Caution must be used when passing a pre-computed `~turbustat.statistics.Bispectrum` instead of the data for `moment0` or `moment0_fid` as there are no checks to ensure the bispectra were computed the same way (e.g., do both have `mean_sub=True` set?). Ensure that the keyword arguments for the pre-computed statistic match those specified to `~turbustat.statistics.Bispectrum_Distance`. See :ref:`the distance metric introduction <runmetrics>`.
 
 References
 ----------

--- a/docs/tutorials/metrics/dendro_example.rst
+++ b/docs/tutorials/metrics/dendro_example.rst
@@ -81,38 +81,9 @@ A line is fit to this relation, and the difference in the slopes of those lines 
 
 For both plots, the plotting labels can be changed from `1` and `2` by setting `label1` and `label2` in `~turbustat.statistics.Dendrogram_Distance.distance_metric`.
 
-For large data sets, creating the dendrogram can be slow. Particularly when comparing many datasets to a fiducial dataset, recomputing the dendrogram each time wastes a lot of time. `~turbustat.statistics.Dendrogram_Distance` can be passed a precomputed `~turbustat.statistics.Dendrogram_Stats` object in two ways:
+For large data sets, creating the dendrogram can be slow. Particularly when comparing many datasets to a fiducial dataset, recomputing the dendrogram each time wastes a lot of time. `~turbustat.statistics.Dendrogram_Distance` can be passed a precomputed `~turbustat.statistics.Dendrogram_Stats` instead of giving a dataset. See :ref:`the distance metric introduction <runmetrics>`.
 
-1. A precomputed `~turbustat.statistics.Dendrogram_Stats` object can be given to `fiducial_model` in `~turbustat.statistics.Dendrogram_Distance`.
-
-    >>> from turbustat.statistics import Dendrogram_Stats
-    >>> dend_stat = Dendrogram_Stats(cube_fid,
-    ...                              min_deltas=np.logspace(-2, 0, 50),
-    ...                              dendro_params={"min_value": 0.005,
-    ...                                             "min_npix": 50})  # doctest: +SKIP
-    >>> dend_stat.run()  # doctest: +SKIP
-    >>> dend_dist = Dendrogram_Distance(cube_fid, cube,
-    ...                                 min_deltas=np.logspace(-2, 0, 50),
-    ...                                 min_features=100,
-    ...                                 dendro_params={"min_value": 0.005,
-    ...                                                "min_npix": 50},
-    ...                                 fiducial_model=dend_stat)  # doctest: +SKIP
-
-    Note that the data (`cube_fid`) still need to be given to `~turbustat.statistics.Dendrogram_Distance`.
-
-    .. warning:: The object given to `fiducial_model` should be run with the same `min_deltas` given to `~turbustat.statistics.Dendrogram_Stats`. The histogram distance is only valid when comparing dendrograms measured with the same deltas.
-
-2. `~turbustat.statistics.Dendrogram_Stats` can be saved as pickle files. When `dataset1` and `dataset2` are given to`~turbustat.statistics.Dendrogram_Distance` as strings, it is assumed that these are pickle files:
-
-    >>> dend_stat.save_results(output_name="Fiducial_Dendrogram_Stats.pkl", keep_data=False)  # doctest: +SKIP
-    >>> dend_dist = Dendrogram_Distance("Fiducial_Dendrogram_Stats.pkl", cube,
-    ...                                 min_deltas=np.logspace(-2, 0, 50),
-    ...                                 min_features=100,
-    ...                                 dendro_params={"min_value": 0.005,
-    ...                                                "min_npix": 50},
-    ...                                 fiducial_model=dend_stat)  # doctest: +SKIP
-
-.. warning:: In both cases, the saved dendrograms should be run with the same `min_deltas` given to `~turbustat.statistics.Dendrogram_Stats`. The histogram distance is only valid when comparing dendrograms measured with the same deltas.
+.. warning:: The saved dendrograms should be run with the same `min_deltas` given to `~turbustat.statistics.Dendrogram_Stats`. The histogram distance is only valid when comparing dendrograms measured with the same deltas.
 
 References
 ----------

--- a/docs/tutorials/metrics/genus_example.rst
+++ b/docs/tutorials/metrics/genus_example.rst
@@ -50,17 +50,7 @@ To find the distance between the images:
 
 This returns a figure that plots the Genus curves of the two images, where the image values are standardized (zero mean and standard deviation of one). Colours, labels, and symbols in the plot can be changed. See `~turbustat.statistics.Genus_Distance.distance_metric`.
 
-When comparing many images to a fiducial image, a pre-computed `~turbustat.statistics.Genus` of the fiducial image can be passed:
-
-    >>> from turbustat.statistics import Genus
-    >>> genus_fid = Genus(moment0_fid, lowdens_percent=15, highdens_percent=85, numpts=100)  # doctest: +SKIP
-    >>> genus_fid.run(min_size=4 * u.pix**2)  # doctest: +SKIP
-    >>> genus = Genus_Distance(moment0_fid, moment0,
-    ...                        lowdens_percent=15, highdens_percent=85, numpts=100,
-    ...                        genus_kwargs=dict(min_size=4 * u.pix**2),
-    ...                        fiducial_model=genus_fid)  # doctest: +SKIP
-
-Note that the data (`moment0_fid`) still need to be given.
+When comparing many images to a fiducial image, a pre-computed `~turbustat.statistics.Genus` can be passed instead of a dataset. See :ref:`the distance metric introduction <runmetrics>`.
 
 References
 ----------

--- a/docs/tutorials/metrics/mvc_example.rst
+++ b/docs/tutorials/metrics/mvc_example.rst
@@ -163,15 +163,7 @@ The distance is now:
     >>> mvc.distance  # doctest: +SKIP
     0.46621655722371613
 
-If many data sets are being compared to a fiducial, a pre-computed `~turbustat.statistics.MVC` class can be passed:
-
-    >>> from turbustat.statistics import MVC
-    >>> mvc_fid = MVC(data_fid['centroid'], data_fid['moment0'],
-    ...               data_fid['linewidth'])  # doctest: +SKIP
-    >>> mvc_fid.run()  # doctest: +SKIP
-    >>> mvc = MVC_Distance(data_fid, data, fiducial_model=mvc_fid)  # doctest: +SKIP
-
-Note that the data still need to be passed to `~turbustat.statistics.MVC_Distance`.
+A pre-computed `~turbustat.statistics.MVC` class can also be passed instead of giving a dataset as the input. See :ref:`the distance metric introduction <runmetrics>`.
 
 References
 ----------

--- a/docs/tutorials/metrics/pca_example.rst
+++ b/docs/tutorials/metrics/pca_example.rst
@@ -50,13 +50,7 @@ And the distance is:
 
 Note that a comparison of the size-line width from PCA as a distance metric is not yet implemented.
 
-If many data sets are being compared to a fiducial, a pre-computed `~turbustat.statistics.PCA` class can be passed:
-
-    >>> from turbustat.statistics import PCA
-    >>> pca_fid = PCA(cube_fid, n_eigs=50).run(decomp_only=True)  # doctest: +SKIP
-    >>> pca = PCA_Distance(cube_fid, cube, fiducial_model=pca_fid)  # doctest: +SKIP
-
-Note that the data still need to be passed to `~turbustat.statistics.PCA_Distance`.
+A pre-computed `~turbustat.statistics.PCA` class can also be passed instead of a dataset. See :ref:`the distance metric introduction <runmetrics>`.
 
 References
 ----------

--- a/docs/tutorials/metrics/pspec_example.rst
+++ b/docs/tutorials/metrics/pspec_example.rst
@@ -96,13 +96,7 @@ The distance between these two images is:
     >>> pspec.distance  # doctest: +SKIP
     3.0952798493530262
 
-When comparing many images to a fiducial image, recomputing the power-spectrum of the fiducial can be avoided by passing a pre-computed `~turbustat.statistics.PowerSpectrum` to `fiducial_model`
-
-    >>> from turbustat.statistics import PowerSpectrum
-    >>> pspec_moment0 = PowerSpectrum(moment0_fid).run()  # doctest: +SKIP
-    >>> pspec = PSpec_Distance(moment0_fid, moment0, fiducial_model=pspec_moment0)  # doctest: +SKIP
-
-Note that the data (`moment0_fid`) must still be given.
+Recomputing an already compute power-spectrum can be avoided by passing a pre-computed `~turbustat.statistics.PowerSpectrum` instead of a dataset. See :ref:`the distance metric introduction <runmetrics>`.
 
 References
 ----------

--- a/docs/tutorials/metrics/running_metrics.rst
+++ b/docs/tutorials/metrics/running_metrics.rst
@@ -5,7 +5,44 @@
 Using distance metrics
 **********************
 
-Common settings
-Passing pre-computed statistics
-When things need to be re-run
-Choosing metrics
+Distance metrics run a statistic on two datasets and use an output of the statistic to quantitatively determine how similar the datasets are. Like the statistic classes, the distance metrics are also `python classes <https://docs.python.org/3/tutorial/classes.html>`_.
+
+.. warning:: Using the distance metrics requires some understanding of how the statistics are computed. Please read the :ref:`introduction to using statistics <runstats>` page.
+
+There is less structure in the distance metric classes compared to the statistic classes. There are two steps to using the distance metrics:
+
+1. **Initialization** -- Like the statistics, unchanging information is given here. The two datasets are given here. However, the statistics are also run from this step, so properties often given to the `run` command for the statistics should be given here.
+
+.. note:: The distance metrics do not always use the full information from a statistic. In these cases, there will be fewer arguments to specify than the statistic's `run` function.
+
+For the `~turbustat.statistics.Wavelet_Distance`, the distance metric is initialized using:
+
+    >>> from turbustat.statistics import Wavelet_Distance
+    >>> from astropy.io import fits
+    >>> hdu = fits.open("file.fits")[0]  # doctest +SKIP
+    >>> hdu2 = fits.open("file2.fits")[0]  # doctest +SKIP
+    >>> wave_dist = Wavelet_Distance(hdu, hdu2, xlow=[5, 7] * u.pix,
+    ...                              xhigh=[30, 35] * u.pix)  # doctest +SKIP
+
+The two datasets are given. For the wavelet transform, the distance is the absolute difference between the slopes, normalized by the square sum of the slope uncertainties. Thus it is important to set the scales that the transform is fit to. Different limits can be given for the two datasets, as shown above, by specifying `xlow` and `xhigh` with two different values. If only a single value is given, it will be used for both datasets. Most parameters that can be specified for one or both of the datasets use this format.
+
+Alternatively, if the wavelet transform has already been computed for one or both of the datasets, the `~turbustat.statistics.Wavelet` can be passed instead of the dataset:
+
+    >>> from turbustat.statistics import Wavelet
+    >>> wave1 = Wavelet(hdu).run()  # doctest +SKIP
+    >>> wave2 = Wavelet(hdu).run()  # doctest +SKIP
+    >>> wave_dist = Wavelet_Distance(wave1, wave2)  # doctest +SKIP
+
+Some distance metrics require that the statistic be computed with a common set of bins or spatial scales. If a `~turbustat.statistics.Wavelet` is given that does not satisfy the criteria, it will be re-run with `~turbustat.statistics.Wavelet_Distance`. The criteria to avoid re-computing a statistic is specified as *Notes* in the distance metric docstrings. See the source code documentation on this site.
+
+2. The second step is to compute the distance metric. In nearly all cases, computing the distance metric is much faster than computing the statistics. All of the distance metric classes have a `distance_metric` function:
+
+    >>> wave_dist.distance_metric(verbose=True)  # doctest +SKIP
+    >>> wave_dist.distance  # doctest +SKIP
+
+The distance is usually an attribute called `distance`. Different names are used when there are multiple distance metrics defined. For example, the `~turbustat.statistics.PDF_Distance` has `hellinger_distance`, `ks_distance`, `lognormal_distance`. See the source code documentation for specifics on each distance metric class. When multiple distance metrics are defined, there are often multiple functions to compute each metric. The `distance_metric` function will usually run all of the distance metrics.
+
+With `verbose=True` in `distance_metric`, a summary plot showing both datasets will be returned. Usually these plots call the plotting function from the statistic classes. Labels to show in the legend for the two datasets can be given.
+
+
+.. note:: The one metric that differs from the rest is the `~turbustat.statistics.Cramer_Distance`. This metric does not have a statistic class because it is a two-sample statistical test. The structure is the same as the rest of the distance metrics but contains more steps to compute the method.

--- a/docs/tutorials/metrics/running_metrics.rst
+++ b/docs/tutorials/metrics/running_metrics.rst
@@ -28,7 +28,7 @@ The two datasets are given. For the wavelet transform, the distance is the absol
 
 Alternatively, if the wavelet transform has already been computed for one or both of the datasets, the `~turbustat.statistics.Wavelet` can be passed instead of the dataset:
 
-    >>> from turbustat.statistics import Wavelet
+    >>> from turbustat.statistics import Wavelet, Wavelet_Distance
     >>> wave1 = Wavelet(hdu).run()  # doctest: +SKIP
     >>> wave2 = Wavelet(hdu).run()  # doctest: +SKIP
     >>> wave_dist = Wavelet_Distance(wave1, wave2)  # doctest: +SKIP

--- a/docs/tutorials/metrics/running_metrics.rst
+++ b/docs/tutorials/metrics/running_metrics.rst
@@ -1,0 +1,11 @@
+.. _runmetrics:
+
+
+**********************
+Using distance metrics
+**********************
+
+Common settings
+Passing pre-computed statistics
+When things need to be re-run
+Choosing metrics

--- a/docs/tutorials/metrics/running_metrics.rst
+++ b/docs/tutorials/metrics/running_metrics.rst
@@ -19,26 +19,26 @@ For the `~turbustat.statistics.Wavelet_Distance`, the distance metric is initial
 
     >>> from turbustat.statistics import Wavelet_Distance
     >>> from astropy.io import fits
-    >>> hdu = fits.open("file.fits")[0]  # doctest +SKIP
-    >>> hdu2 = fits.open("file2.fits")[0]  # doctest +SKIP
+    >>> hdu = fits.open("file.fits")[0]  # doctest: +SKIP
+    >>> hdu2 = fits.open("file2.fits")[0]  # doctest: +SKIP
     >>> wave_dist = Wavelet_Distance(hdu, hdu2, xlow=[5, 7] * u.pix,
-    ...                              xhigh=[30, 35] * u.pix)  # doctest +SKIP
+    ...                              xhigh=[30, 35] * u.pix)  # doctest: +SKIP
 
 The two datasets are given. For the wavelet transform, the distance is the absolute difference between the slopes, normalized by the square sum of the slope uncertainties. Thus it is important to set the scales that the transform is fit to. Different limits can be given for the two datasets, as shown above, by specifying `xlow` and `xhigh` with two different values. If only a single value is given, it will be used for both datasets. Most parameters that can be specified for one or both of the datasets use this format.
 
 Alternatively, if the wavelet transform has already been computed for one or both of the datasets, the `~turbustat.statistics.Wavelet` can be passed instead of the dataset:
 
     >>> from turbustat.statistics import Wavelet
-    >>> wave1 = Wavelet(hdu).run()  # doctest +SKIP
-    >>> wave2 = Wavelet(hdu).run()  # doctest +SKIP
-    >>> wave_dist = Wavelet_Distance(wave1, wave2)  # doctest +SKIP
+    >>> wave1 = Wavelet(hdu).run()  # doctest: +SKIP
+    >>> wave2 = Wavelet(hdu).run()  # doctest: +SKIP
+    >>> wave_dist = Wavelet_Distance(wave1, wave2)  # doctest: +SKIP
 
 Some distance metrics require that the statistic be computed with a common set of bins or spatial scales. If a `~turbustat.statistics.Wavelet` is given that does not satisfy the criteria, it will be re-run with `~turbustat.statistics.Wavelet_Distance`. The criteria to avoid re-computing a statistic is specified as *Notes* in the distance metric docstrings. See the source code documentation on this site.
 
 2. The second step is to compute the distance metric. In nearly all cases, computing the distance metric is much faster than computing the statistics. All of the distance metric classes have a `distance_metric` function:
 
-    >>> wave_dist.distance_metric(verbose=True)  # doctest +SKIP
-    >>> wave_dist.distance  # doctest +SKIP
+    >>> wave_dist.distance_metric(verbose=True)  # doctest: +SKIP
+    >>> wave_dist.distance  # doctest: +SKIP
 
 The distance is usually an attribute called `distance`. Different names are used when there are multiple distance metrics defined. For example, the `~turbustat.statistics.PDF_Distance` has `hellinger_distance`, `ks_distance`, `lognormal_distance`. See the source code documentation for specifics on each distance metric class. When multiple distance metrics are defined, there are often multiple functions to compute each metric. The `distance_metric` function will usually run all of the distance metrics.
 

--- a/docs/tutorials/metrics/scf_example.rst
+++ b/docs/tutorials/metrics/scf_example.rst
@@ -53,13 +53,8 @@ The distance between the SCF surfaces is:
 
 By default, the distance between the surfaces is weighted by the lag (see equation above). This weighting can be disabled by setting `weighted=False` in `~turbustat.statistics.SCF_Distance.distance_metric`, and the distance metrics reduces to the L2 norm between the surfaces.
 
-If many data sets are being compared to a fiducial, a pre-computed `~turbustat.statistics.SCF` class can be passed:
+A pre-computed `~turbustat.statistics.SCF` class can be also passed instead of a data cube. However, the SCF will need to be recomputed if the lags are different from the common set defined in `~turbustat.statistics.SCF_Distance`. See :ref:`the distance metric introduction <runmetrics>`.
 
-    >>> from turbustat.statistics import SCF
-    >>> scf_fid = SCF(cube_fid, size=11).run()  # doctest: +SKIP
-    >>> scf = SCF_Distance(cube_fid, cube, fiducial_model=scf_fid)  # doctest: +SKIP
-
-It is critical that the lags used in `~turbustat.statistics.SCF` match the common set of lags that are used in `~turbustat.statistics.SCF_Distance`. Also note that the data still need to be passed to `~turbustat.statistics.SCF_Distance`.
 
 References
 ----------

--- a/docs/tutorials/metrics/statmoments_example.rst
+++ b/docs/tutorials/metrics/statmoments_example.rst
@@ -56,13 +56,7 @@ The distances for the skewness and kurtosis are:
     >>> print(moments.skewness_distance, moments.kurtosis_distance)  # doctest: +SKIP
     0.01189910501201634 0.019870935761084074
 
-If many data sets are being compared to a fiducial, a pre-computed `~turbustat.statistics.StatMoments` class can be passed:
-
-    >>> from turbustat.statistics import StatMoments
-    >>> moments_fid = StatMoments(moment0_fid, size=5 * u.pix).run()  # doctest: +SKIP
-    >>> moments = StatMoments_Distance(moment0_fid, moment0, fiducial_model=moments_fid)  # doctest: +SKIP
-
-It is critical that the `size` used in `~turbustat.statistics.StatMoments` match the common set of lags that are used in `~turbustat.statistics.StatMoments_Distance`. Also note that the data still needs to be passed to `~turbustat.statistics.StatMoments_Distance`.
+A pre-computed `~turbustat.statistics.StatMoments` class can be passed instead of an image. However, the moments will need to be recomputed if the `size` differs from the common scale determined in `~turbustat.statistics.StatMoments_Distance`. See :ref:`the distance metric introduction <runmetrics>`.
 
 References
 ----------

--- a/docs/tutorials/metrics/vca_example.rst
+++ b/docs/tutorials/metrics/vca_example.rst
@@ -160,16 +160,7 @@ The VCA power-spectra with 400 m/s channels have a similar slope to the original
     >>> vca.distance  # doctest: +SKIP
     5.164776059129051
 
-If many data sets are being compared to a fiducial, a pre-computed `~turbustat.statistics.VCA` class can be passed:
-
-    >>> from turbustat.statistics import VCA
-    >>> vca_fid = VCA(cube_fid).run(low_cut=0.025 / u.pix,
-    ...                             high_cut=0.1 / u.pix)  # doctest: +SKIP
-    >>> vca = VCA_Distance(cube_fid, cube, fiducial_model=vca_fid,
-    ...                    low_cut=0.025 / u.pix,
-    ...                    high_cut=0.1 / u.pix)  # doctest: +SKIP
-
-Note that the data still need to be passed to `~turbustat.statistics.VCA_Distance`.
+A pre-computed `~turbustat.statistics.VCA` class can be also passed instead of a data cube. See :ref:`the distance metric introduction <runmetrics>`.
 
 References
 ----------

--- a/docs/tutorials/metrics/vcs_example.rst
+++ b/docs/tutorials/metrics/vcs_example.rst
@@ -131,16 +131,7 @@ The distances between the cubes, as defined above, are:
 
 The difference in the slopes is dominated by `vcs.large_scale_distance`, while the small-scale slopes are quite similar. The break locations are also similar and give a small `vcs.break_distance`.
 
-If many data sets are being compared to a fiducial, a pre-computed `~turbustat.statistics.VCS` class can be passed:
-
-    >>> from turbustat.statistics import VCS
-    >>> vcs_fid = VCS(cube_fid).run(low_cut=0.025 / u.pix,
-    ...                             high_cut=0.1 / u.pix)  # doctest: +SKIP
-    >>> vcs = VCS_Distance(cube_fid, cube, fiducial_model=vcs_fid,
-    ...                    fit_kwargs=dict(low_cut=0.025 / u.pix,
-    ...                                    high_cut=0.1 / u.pix)  # doctest: +SKIP
-
-Note that the data still need to be passed to `~turbustat.statistics.VCS_Distance`.
+A pre-computed `~turbustat.statistics.VCS` class can be also passed instead of a data cube. See :ref:`the distance metric introduction <runmetrics>`.
 
 References
 ----------

--- a/docs/tutorials/metrics/wavelet_example.rst
+++ b/docs/tutorials/metrics/wavelet_example.rst
@@ -98,15 +98,7 @@ The distances between these two datasets are:
     >>> wavelet.curve_distance  # doctest: +SKIP
     9.81949754947785
 
-If many data sets are being compared to a fiducial, a pre-computed `~turbustat.statistics.Wavelet` class can be passed:
-
-    >>> from turbustat.statistics import Wavelet
-    >>> wave_fid = Wavelet(moment0_fid).run(xlow=2 * u.pix,
-    ...                                     xhigh=10 * u.pix)  # doctest: +SKIP
-    >>> wavelet = Wavelet_Distance(moment0_fid, moment0, xlow=2 * u.pix,
-    ...                            xhigh=10 * u.pix, fiducial_model=wave_fid)  # doctest: +SKIP
-
-Note that the data still need to be passed to `~turbustat.statistics.Wavelet_Distance`.
+A pre-computed `~turbustat.statistics.Wavelet` class can be also passed instead of a data cube. See :ref:`the distance metric introduction <runmetrics>`.
 
 References
 ----------

--- a/docs/tutorials/statistics/running_statistics.rst
+++ b/docs/tutorials/statistics/running_statistics.rst
@@ -12,6 +12,7 @@ Using most of the statistic classes will involved two steps:
 1. **Initialization** -- The data, relevant WCS information, and other unchanging properties (like the distance) are specified here. Some of the statistics calculated at specific scales (like `~turbustat.statistics.Wavelet` or `~turbustat.statistics.SCF`) can have those scales set here, too. Below is an example using `~turbustat.statistics.Wavelet`:
 
     >>> from turbustat.statistics import Wavelet
+    >>> import numpy as np
     >>> from astropy.io import fits
     >>> from astropy.units import u
     >>> hdu = fits.open("file.fits")[0]  # doctest: +SKIP

--- a/docs/tutorials/statistics/running_statistics.rst
+++ b/docs/tutorials/statistics/running_statistics.rst
@@ -1,0 +1,45 @@
+.. _runstats:
+
+
+************************
+Using statistics classes
+************************
+
+The statistics implemented in TurbuStat are `python classes <https://docs.python.org/3/tutorial/classes.html>`_. This structure allows for derived properties to persist without having to manually carry them forward through each step.
+
+Using most of the statistic classes will involved two steps:
+
+1. **Initialization** -- The data, relevant WCS information, and other unchanging properties (like the distance) are specified here. Some of the statistics calculated at specific scales (like `~turbustat.statistics.Wavelet` or `~turbustat.statistics.SCF`) can have those scales set here, too. Below is an example using `~turbustat.statistics.Wavelet`:
+
+    >>> from turbustat.statistics import Wavelet
+    >>> from astropy.io import fits
+    >>> from astropy.units import u
+    >>> hdu = fits.open("file.fits")[0]  # doctest: +SKIP
+    >>> spatial_scales = np.linspace(0.1, 1.0, 20) * u.pc
+    >>> wave = Wavelet(hdu, scales=spatial_scales,
+    ...                distance=260 * u.pc)  # doctest: +SKIP
+
+2. **The run function** -- For most use-cases, the `run` function can be used to compute the statistic. All of the statistics have this function. It will compute the statistic, perform any relevant fitting, and optionally create a summary plot. The docstring for each of the `run` functions describe the parameters that can be changed from this function. The parameters that are critical to the behaviour of the statistic can all be set from `run`. Continuing with the `~turbustat.statistics.Wavelet` example from above, the `run` function is called as:
+
+    >>> wave.run(verbose=True, xlow=0.2 * u.pc, xhigh=0.8 * u.pc)  # doctest: +SKIP
+
+This function will run the wavelet transform and fit the relation between the given bounds (`xlow` and `xhigh`). With `verbose=True`, a summary plot is returned.
+
+
+What if you need to set parameters not accessible from `run`? `run` wraps multiple steps in one function, however, the statistic can be run in steps when fine-tuning is needed for a particular data set. Each of the statistics has at least one computational step. For `~turbustat.statistics.Wavelet`, there are two steps: (1) computing the transform (`~turbustat.statistics.Wavelet.compute_transform`) and (2) fitting the log of the transform (`~turbustat.statistics.Wavelet.fit_transform`). Running these two functions is equivalent to using `run`.
+
+The statistics also have plotting functions. From `run`, these functions are called whenever `verbose=True` is given. All of the plotting functions start with `plot_`; for `~turbustat.statistics.Wavelet`, the plotting function is `~turbustat.statistics.Wavelet.plot_transform`. Supplying a `save_name` to this function will save the figure, the x-units can also be set for spatial transforms (like the wavelet transform) as pixel, angular, or physical (when a distance is given) units, and additional arguments can be given to set the colours and markers used in the plot.
+
+Statistic classes can also be saved or loaded as pickle files. Saving is performed with the `save_results` function:
+
+    >>> wave.save_results("wave_file.pkl", keep_data=False)  # doctest: +SKIP
+
+Whether to include the data in saved file is set with `keep_data`. By default, the data is *not* saved to save storage space.
+
+.. note:: If the statistic is not saved with the data, it cannot be recomputed after loading.
+
+Loading the statistic from a saved file uses the `load_results` function:
+
+    >>> new_wave = Wavelet.load_results("wav_file.pkl")  # doctest: +SKIP
+
+Unless the data is saved, everything but the data is new accessible from `new_wave`.

--- a/docs/tutorials/statistics/running_statistics.rst
+++ b/docs/tutorials/statistics/running_statistics.rst
@@ -16,7 +16,7 @@ Using most of the statistic classes will involved two steps:
     >>> from astropy.io import fits
     >>> from astropy.units import u
     >>> hdu = fits.open("file.fits")[0]  # doctest: +SKIP
-    >>> spatial_scales = np.linspace(0.1, 1.0, 20) * u.pc
+    >>> spatial_scales = np.linspace(0.1, 1.0, 20) * u.pc   # doctest: +SKIP
     >>> wave = Wavelet(hdu, scales=spatial_scales,
     ...                distance=260 * u.pc)  # doctest: +SKIP
 

--- a/turbustat/statistics/genus/genus.py
+++ b/turbustat/statistics/genus/genus.py
@@ -332,6 +332,9 @@ class Genus_Distance(object):
     """
     Distance Metric for the Genus Statistic.
 
+    .. note:: Since the data need to be normalized for the distance metrics,
+              there is no option to pass a pre-compute `~Genus` statistic.
+
     Parameters
     ----------
     img1 : %(dtypes)s
@@ -363,8 +366,6 @@ class Genus_Distance(object):
     genus2_kwargs : None or dict, optional
         Dictionary passed to `~Genus.run` for `img2`. When `None` is given,
         settings from `genus_kwargs` are used  for `img2`.
-    fiducial_model : Genus
-        Computed Genus object. Use to avoid recomputing.
     """
 
     __doc__ %= {"dtypes": " or ".join(common_types + twod_types)}
@@ -372,8 +373,7 @@ class Genus_Distance(object):
     def __init__(self, img1, img2, smoothing_radii=None, numpts=100,
                  min_value=None, max_value=None, lowdens_percent=0,
                  highdens_percent=100,
-                 genus_kwargs={}, genus2_kwargs=None,
-                 fiducial_model=None):
+                 genus_kwargs={}, genus2_kwargs=None):
 
         # Check if list for inputs, where first is for img1 and second is
         # for img2
@@ -400,14 +400,11 @@ class Genus_Distance(object):
         img1 = standardize(img1)
         img2 = standardize(img2)
 
-        if fiducial_model is not None:
-            self.genus1 = fiducial_model
-        else:
-            self.genus1 = Genus(img1, smoothing_radii=smoothing_radii,
-                                min_value=min_value[0], max_value=max_value[0],
-                                lowdens_percent=lowdens_percent[0],
-                                highdens_percent=highdens_percent[0])
-            self.genus1.run(**genus_kwargs)
+        self.genus1 = Genus(img1, smoothing_radii=smoothing_radii,
+                            min_value=min_value[0], max_value=max_value[0],
+                            lowdens_percent=lowdens_percent[0],
+                            highdens_percent=highdens_percent[0])
+        self.genus1.run(**genus_kwargs)
 
         self.genus2 = Genus(img2, smoothing_radii=smoothing_radii,
                             min_value=min_value[1], max_value=max_value[1],

--- a/turbustat/statistics/pca/pca.py
+++ b/turbustat/statistics/pca/pca.py
@@ -978,9 +978,9 @@ class PCA_Distance(object):
     Parameters
     ----------
     cube1 : %(dtypes)s or `~PCA`
-        Data cube.
+        Data cube. Or a `~PCA` class can be given which may be pre-computed.
     cube2 : %(dtypes)s or `~PCA`
-        Data cube.
+        Data cube. Or a `~PCA` class can be given which may be pre-computed.
     n_eigs : int
         Number of eigenvalues to compute.
     fiducial_model : PCA

--- a/turbustat/statistics/pdf/compare_pdf.py
+++ b/turbustat/statistics/pdf/compare_pdf.py
@@ -544,6 +544,10 @@ class PDF_Distance(object):
     '''
     Calculate the distance between two arrays using their PDFs.
 
+    .. note:: Pre-computed `~PDF` classes cannot be passed to `~PDF_Distance`
+              as the data need to be normalized and the PDFs should use the
+              same set of histogram bins.
+
     Parameters
     ----------
     img1 : %(dtypes)s

--- a/turbustat/statistics/pspec_bispec/bispec.py
+++ b/turbustat/statistics/pspec_bispec/bispec.py
@@ -515,28 +515,50 @@ class Bispectrum_Distance(object):
 
     Parameters
     ----------
-    data1 : %(dtypes)s
-        Contains the data and header of the image.
-    data2 : %(dtypes)s
-        Contains the data and header of the image.
-    nsamples : int, optional
-        Sets the number of samples to take at each vector magnitude.
-    fiducial_model : Bispectrum
-        Computed Bispectrum object. use to avoid recomputing.
+    data1 : %(dtypes)s or `~Bispectrum`
+        Contains the data and header of the image. Or a `~Bispectrum` class may
+        be given which can be pre-computed.
+    data2 : %(dtypes)s or `~Bispectrum`
+        Contains the data and header of the second image. Or a `~Bispectrum`
+        class may be given which can be pre-computed.
+    stat_kwargs : dict, optional
+        Passed to `~Bispectrum.run`.
     '''
 
     __doc__ %= {"dtypes": " or ".join(common_types + twod_types)}
 
-    def __init__(self, data1, data2, stat_kwargs={}, fiducial_model=None):
+    def __init__(self, data1, data2, stat_kwargs={}):
 
-        if fiducial_model is not None:
-            self.bispec1 = fiducial_model
+        # if fiducial_model is not None:
+        #     self.bispec1 = fiducial_model
+
+        if isinstance(data1, Bispectrum):
+            self.bispec1 = data1
+            needs_run = False
+            if not hasattr(self.bispec1, '_bicoherence'):
+                needs_run = True
+                warn("Bispectrum given as data1 does not have a"
+                     " bicoherence surface. Re-running Bispectrum.")
         else:
             self.bispec1 = BiSpectrum(data1)
+            needs_run = True
+
+        if needs_run:
             self.bispec1.run(**stat_kwargs)
 
-        self.bispec2 = BiSpectrum(data2)
-        self.bispec2.run(**stat_kwargs)
+        if isinstance(data2, Bispectrum):
+            self.bispec2 = data2
+            needs_run = False
+            if not hasattr(self.bispec2, '_bicoherence'):
+                needs_run = True
+                warn("Bispectrum given as data2 does not have a"
+                     " bicoherence surface. Re-running Bispectrum.")
+        else:
+            self.bispec2 = BiSpectrum(data2)
+            needs_run = True
+
+        if needs_run:
+            self.bispec2.run(**stat_kwargs)
 
     @property
     def surface_distance(self):

--- a/turbustat/statistics/pspec_bispec/pspec.py
+++ b/turbustat/statistics/pspec_bispec/pspec.py
@@ -228,10 +228,11 @@ class PSpec_Distance(object):
     Parameters
     ----------
 
-    data1 : %(dtypes)s
-        Data with an associated header.
-    data2 : %(dtypes)s
-        See data1.
+    data1 : %(dtypes)s or `~PowerSpectrum`
+        Data with an associated header. Or a `~PowerSpectrum` class which
+        may be pre-computed.
+    data2 : %(dtypes)s or `~PowerSpectrum`
+        See `data1`.
     weights1 : %(dtypes)s, optional
         Weights to apply to data1
     weights2 : %(dtypes)s, optional

--- a/turbustat/statistics/vca_vcs/vca.py
+++ b/turbustat/statistics/vca_vcs/vca.py
@@ -254,8 +254,6 @@ class VCA_Distance(object):
     pspec2_kwargs : dict or None, optional
         Passed to `radial_pspec_kwargs` in `~PowerSpectrum.run` for `cube2`.
         When `None` is given, setting from `pspec_kwargs` are used for `cube2`.
-    fiducial_model : `~turbustat.statistics.VCA`
-        Computed VCA object. use to avoid recomputing.
     phys_distance : `~astropy.units.Quantity`, optional
         Physical distance to the region in the data.
     '''
@@ -275,8 +273,6 @@ class VCA_Distance(object):
         if radial_pspec_kwargs2 is None:
             radial_pspec_kwargs2 = radial_pspec_kwargs
 
-        # if fiducial_model is not None:
-        #     self.vca1 = fiducial_model
         if isinstance(cube1, VCA):
             self.vca1 = cube1
             needs_run = False

--- a/turbustat/tests/test_bispec.py
+++ b/turbustat/tests/test_bispec.py
@@ -62,6 +62,34 @@ def test_Bispec_distance():
     npt.assert_almost_equal(tester_dist.mean_distance,
                             computed_distances['bispec_mean_distance'])
 
+    # With pre-computed Bispectrum inputs
+
+    tester_dist2 = \
+        Bispectrum_Distance(tester_dist.bispec1,
+                            tester_dist.bispec2)
+    tester_dist2.distance_metric()
+
+    npt.assert_almost_equal(tester_dist2.surface_distance,
+                            computed_distances['bispec_surface_distance'])
+
+    npt.assert_almost_equal(tester_dist2.mean_distance,
+                            computed_distances['bispec_mean_distance'])
+
+    # With fresh Bispectrum instances
+    tester = Bispectrum(dataset1["moment0"])
+    tester2 = Bispectrum(dataset2["moment0"])
+
+    tester_dist3 = \
+        Bispectrum_Distance(tester,
+                            tester2)
+    tester_dist3.distance_metric()
+
+    npt.assert_almost_equal(tester_dist3.surface_distance,
+                            computed_distances['bispec_surface_distance'])
+
+    npt.assert_almost_equal(tester_dist3.mean_distance,
+                            computed_distances['bispec_mean_distance'])
+
 
 def test_bispec_azimuthal_slicing():
 

--- a/turbustat/tests/test_delvar.py
+++ b/turbustat/tests/test_delvar.py
@@ -121,6 +121,39 @@ def test_DelVar_distance():
                             computed_distances['delvar_slope_distance'],
                             decimal=3)
 
+    # Try distance metric when giving DeltaVariance classes as inputs
+    tester_dist2 = \
+        DeltaVariance_Distance(tester_dist.delvar1,
+                               tester_dist.delvar2)
+    tester_dist2.distance_metric(verbose=False)
+
+    npt.assert_almost_equal(tester_dist2.curve_distance,
+                            computed_distances['delvar_curve_distance'],
+                            decimal=3)
+    npt.assert_almost_equal(tester_dist2.slope_distance,
+                            computed_distances['delvar_slope_distance'],
+                            decimal=3)
+
+    # And test when given DeltaVariance classes that haven't been run yet.
+    tester = \
+        DeltaVariance(dataset1["moment0"],
+                      weights=dataset1['moment0_error'][0])
+    tester2 = \
+        DeltaVariance(dataset2["moment0"],
+                      weights=dataset2['moment0_error'][0])
+
+    tester_dist3 = \
+        DeltaVariance_Distance(tester, tester2,
+                               delvar_kwargs=dict(xhigh=11 * u.pix))
+    tester_dist3.distance_metric(verbose=False)
+
+    npt.assert_almost_equal(tester_dist3.curve_distance,
+                            computed_distances['delvar_curve_distance'],
+                            decimal=3)
+    npt.assert_almost_equal(tester_dist3.slope_distance,
+                            computed_distances['delvar_slope_distance'],
+                            decimal=3)
+
 
 @pytest.mark.skipif("not PYFFTW_INSTALLED")
 def test_DelVar_method_fftw():

--- a/turbustat/tests/test_dendro.py
+++ b/turbustat/tests/test_dendro.py
@@ -64,3 +64,35 @@ def test_DendroDistance():
                             computed_distances["dendrohist_distance"])
     npt.assert_almost_equal(tester_dist.num_distance,
                             computed_distances["dendronum_distance"])
+
+    # With Dendrogram_Stats as inputs
+
+    tester_dist2 = \
+        DendroDistance(tester_dist.dendro1,
+                       tester_dist.dendro2,
+                       min_deltas=min_deltas,
+                       dendro_kwargs=dict(periodic_bounds=False))
+    tester_dist2.distance_metric(verbose=False)
+
+    npt.assert_almost_equal(tester_dist2.histogram_distance,
+                            computed_distances["dendrohist_distance"])
+    npt.assert_almost_equal(tester_dist2.num_distance,
+                            computed_distances["dendronum_distance"])
+
+    # With uncomputed Dendrogram_Stats
+    tester = Dendrogram_Stats(dataset1["cube"],
+                              min_deltas=min_deltas)
+    tester2 = Dendrogram_Stats(dataset2["cube"],
+                               min_deltas=min_deltas)
+
+    tester_dist3 = \
+        DendroDistance(tester,
+                       tester2,
+                       min_deltas=min_deltas,
+                       dendro_kwargs=dict(periodic_bounds=False))
+    tester_dist3.distance_metric(verbose=False)
+
+    npt.assert_almost_equal(tester_dist3.histogram_distance,
+                            computed_distances["dendrohist_distance"])
+    npt.assert_almost_equal(tester_dist3.num_distance,
+                            computed_distances["dendronum_distance"])

--- a/turbustat/tests/test_mvc.py
+++ b/turbustat/tests/test_mvc.py
@@ -59,6 +59,7 @@ def test_MVC_method():
     npt.assert_allclose(saved_tester.slope2D, computed_data['mvc_slope2D'],
                         rtol=1e-4)
 
+
 def test_MVC_method_fitlimits():
 
     distance = 250 * u.pc
@@ -102,6 +103,34 @@ def test_MVC_distance():
 
     # Tiny discrepancy introduced when using rfft_to_fft instead of np.fft.fft2
     npt.assert_allclose(tester_dist.distance,
+                        computed_distances['mvc_distance'],
+                        rtol=2e-3)
+
+    # Test with MVC classes as inputs
+    tester_dist2 = \
+        MVC_Distance(tester_dist.mvc1, tester_dist.mvc2)
+    tester_dist2.distance_metric(verbose=False)
+
+    # Tiny discrepancy introduced when using rfft_to_fft instead of np.fft.fft2
+    npt.assert_allclose(tester_dist2.distance,
+                        computed_distances['mvc_distance'],
+                        rtol=2e-3)
+
+    # Now from fresh MVC classes that need to be computed
+    tester = MVC(dataset1["centroid"],
+                 dataset1["moment0"],
+                 dataset1["linewidth"],
+                 dataset1["centroid"][1])
+    tester2 = MVC(dataset2["centroid"],
+                  dataset2["moment0"],
+                  dataset2["linewidth"],
+                  dataset2["centroid"][1])
+    tester_dist3 = \
+        MVC_Distance(tester, tester2)
+    tester_dist3.distance_metric(verbose=False)
+
+    # Tiny discrepancy introduced when using rfft_to_fft instead of np.fft.fft2
+    npt.assert_allclose(tester_dist3.distance,
                         computed_distances['mvc_distance'],
                         rtol=2e-3)
 

--- a/turbustat/tests/test_pca.py
+++ b/turbustat/tests/test_pca.py
@@ -171,6 +171,27 @@ def test_PCA_distance():
     npt.assert_almost_equal(tester_dist.distance,
                             computed_distances['pca_distance'])
 
+    # With PCA classes as inputs
+    tester_dist2 = \
+        PCA_Distance(tester_dist.pca1,
+                     tester_dist.pca2)
+    tester_dist2.distance_metric(verbose=False)
+
+    npt.assert_almost_equal(tester_dist2.distance,
+                            computed_distances['pca_distance'])
+
+    # With fresh PCA classes
+    tester = PCA(dataset1["cube"])
+    tester2 = PCA(dataset2["cube"])
+
+    tester_dist3 = \
+        PCA_Distance(tester,
+                     tester2)
+    tester_dist3.distance_metric(verbose=False)
+
+    npt.assert_almost_equal(tester_dist3.distance,
+                            computed_distances['pca_distance'])
+
 
 @pytest.mark.parametrize(('method'), ('fit', 'contour', 'interpolate',
                                       'xinterpolate'))

--- a/turbustat/tests/test_pspec.py
+++ b/turbustat/tests/test_pspec.py
@@ -89,6 +89,28 @@ def test_PSpec_distance():
     npt.assert_almost_equal(tester_dist.distance,
                             computed_distances['pspec_distance'])
 
+    # With pre-computed pspec
+
+    tester_dist2 = \
+        PSpec_Distance(tester_dist.pspec1,
+                       tester_dist.pspec2)
+    tester_dist2.distance_metric(verbose=False)
+
+    npt.assert_almost_equal(tester_dist2.distance,
+                            computed_distances['pspec_distance'])
+
+    # With fresh pspec instances
+    tester = PowerSpectrum(dataset1["moment0"])
+    tester2 = PowerSpectrum(dataset2["moment0"])
+
+    tester_dist3 = \
+        PSpec_Distance(tester,
+                       tester2)
+    tester_dist3.distance_metric(verbose=False)
+
+    npt.assert_almost_equal(tester_dist3.distance,
+                            computed_distances['pspec_distance'])
+
 
 def test_pspec_nonequal_shape():
 

--- a/turbustat/tests/test_scf.py
+++ b/turbustat/tests/test_scf.py
@@ -141,6 +141,28 @@ def test_SCF_distance():
     npt.assert_almost_equal(tester_dist.distance,
                             computed_distances['scf_distance'])
 
+    # With pre-computed SCF classes
+
+    tester_dist2 = \
+        SCF_Distance(tester_dist.scf1,
+                     tester_dist.scf2, size=11)
+    tester_dist2.distance_metric()
+
+    npt.assert_almost_equal(tester_dist2.distance,
+                            computed_distances['scf_distance'])
+
+    # With fresh SCF instances
+    tester = SCF(dataset1["cube"], size=11)
+    tester2 = SCF(dataset2["cube"], size=11)
+
+    tester_dist3 = \
+        SCF_Distance(tester,
+                     tester2, size=11)
+    tester_dist3.distance_metric()
+
+    npt.assert_almost_equal(tester_dist3.distance,
+                            computed_distances['scf_distance'])
+
 
 def test_SCF_regrid_distance():
     hdr = dataset1["cube"][1].copy()

--- a/turbustat/tests/test_stat_moments.py
+++ b/turbustat/tests/test_stat_moments.py
@@ -100,3 +100,39 @@ def test_moment_distance():
                             computed_distances['kurtosis_distance'])
     npt.assert_almost_equal(tester_dist.skewness_distance,
                             computed_distances['skewness_distance'])
+
+    # With StatMoments classes as inputs
+
+    tester_dist2 = \
+        StatMoments_Distance(tester_dist.moments1,
+                             tester_dist.moments2)
+    tester_dist2.distance_metric()
+
+    assert np.allclose(tester_dist2.moments1.kurtosis_hist[1],
+                       computed_data['kurtosis_val'])
+    assert np.allclose(tester_dist2.moments1.skewness_hist[1],
+                       computed_data['skewness_val'])
+
+    npt.assert_almost_equal(tester_dist2.kurtosis_distance,
+                            computed_distances['kurtosis_distance'])
+    npt.assert_almost_equal(tester_dist2.skewness_distance,
+                            computed_distances['skewness_distance'])
+
+    # With fresh StatMoments classes
+    tester = StatMoments(dataset1["moment0"])
+    tester2 = StatMoments(dataset2["moment0"])
+
+    tester_dist3 = \
+        StatMoments_Distance(tester,
+                             tester2)
+    tester_dist3.distance_metric()
+
+    assert np.allclose(tester_dist3.moments1.kurtosis_hist[1],
+                       computed_data['kurtosis_val'])
+    assert np.allclose(tester_dist3.moments1.skewness_hist[1],
+                       computed_data['skewness_val'])
+
+    npt.assert_almost_equal(tester_dist3.kurtosis_distance,
+                            computed_distances['kurtosis_distance'])
+    npt.assert_almost_equal(tester_dist3.skewness_distance,
+                            computed_distances['skewness_distance'])

--- a/turbustat/tests/test_vca.py
+++ b/turbustat/tests/test_vca.py
@@ -109,6 +109,27 @@ def test_VCA_distance():
     npt.assert_almost_equal(tester_dist.distance,
                             computed_distances['vca_distance'])
 
+    # With pre-computed VCA classes as inputs
+    tester_dist2 = \
+        VCA_Distance(tester_dist.vca1,
+                     tester_dist.vca2)
+    tester_dist2.distance_metric()
+
+    npt.assert_almost_equal(tester_dist2.distance,
+                            computed_distances['vca_distance'])
+
+    # With fresh VCA classes as inputs
+    tester = VCA(dataset1["cube"])
+    tester2 = VCA(dataset2["cube"])
+
+    tester_dist3 = \
+        VCA_Distance(tester,
+                     tester2)
+    tester_dist3.distance_metric()
+
+    npt.assert_almost_equal(tester_dist3.distance,
+                            computed_distances['vca_distance'])
+
 
 @pytest.mark.parametrize(("regrid_type", "channel_width"),
                          [['downsample', 2 * u.pix], ['downsample', 2],

--- a/turbustat/tests/test_vcs.py
+++ b/turbustat/tests/test_vcs.py
@@ -53,11 +53,34 @@ def test_VCS_distance():
         VCS_Distance(dataset1["cube"], dataset2["cube"],
                      fit_kwargs=dict(high_cut=0.3 / u.pix,
                                      low_cut=3e-2 / u.pix))
-    tester_dist = tester_dist.distance_metric(verbose=True,
-                                              save_name='test.png')
+    tester_dist.distance_metric(verbose=True, save_name='test.png')
     os.system("rm test.png")
 
     npt.assert_almost_equal(tester_dist.distance,
+                            computed_distances['vcs_distance'])
+
+    # With pre-computed VCS classes as inputs
+
+    tester_dist2 = \
+        VCS_Distance(tester_dist.vcs1, tester_dist.vcs2,
+                     fit_kwargs=dict(high_cut=0.3 / u.pix,
+                                     low_cut=3e-2 / u.pix))
+    tester_dist2.distance_metric()
+
+    npt.assert_almost_equal(tester_dist2.distance,
+                            computed_distances['vcs_distance'])
+
+    # With fresh VCS classes as inputs
+    tester = VCS(dataset1["cube"])
+    tester2 = VCS(dataset2["cube"])
+
+    tester_dist3 = \
+        VCS_Distance(tester, tester2,
+                     fit_kwargs=dict(high_cut=0.3 / u.pix,
+                                     low_cut=3e-2 / u.pix))
+    tester_dist3.distance_metric()
+
+    npt.assert_almost_equal(tester_dist3.distance,
                             computed_distances['vcs_distance'])
 
 

--- a/turbustat/tests/test_wavelet.py
+++ b/turbustat/tests/test_wavelet.py
@@ -129,6 +129,27 @@ def test_Wavelet_distance():
     npt.assert_almost_equal(tester_dist.distance,
                             computed_distances['wavelet_distance'])
 
+    # With pre-computed Wavelet classes as input
+    tester_dist2 = \
+        Wavelet_Distance(tester_dist.wt1,
+                         tester_dist.wt2)
+    tester_dist2.distance_metric()
+
+    npt.assert_almost_equal(tester_dist2.distance,
+                            computed_distances['wavelet_distance'])
+
+    # With fresh Wavelet classes as input
+    tester = Wavelet(dataset1["moment0"])
+    tester2 = Wavelet(dataset2["moment0"])
+
+    tester_dist3 = \
+        Wavelet_Distance(tester,
+                         tester2)
+    tester_dist3.distance_metric()
+
+    npt.assert_almost_equal(tester_dist3.distance,
+                            computed_distances['wavelet_distance'])
+
 
 @pytest.mark.skipif("not PYFFTW_INSTALLED")
 def test_Wavelet_method_fftw():


### PR DESCRIPTION
Most of the distance classes allowed passing only one pre-computed statistic classes. Other (PCA; Dendrograms) would accept strings to load saved pickle files of statistics. This PR abolishes the use of `fiducial_model` as a kwarg in all of the distance classes and allows stats classes to be passed like data sets are to the distance metrics. 

The following can now be used:
```
pca1 = PCA(cube1).run()
pca2 = PCA(cube2).run()
pca_dist = PCA_Distance(pca1, pca2)
```
Previously, the user would have needed to do the following:
```
pca1 = PCA(cube).run()
pca_dist = PCA_DIstance(cube1, cube2, fiducial_model=pca1)
```

Some metrics require recomputing the statistics if some criterion is not met (e.g., the radius needs to be the same in `StatMoments_Distance` for a useful comparison).

* [x] Update metric tutorials
* [x] Add page on general structure of statistic and distance classes
