### PR TITLE
Remove six import from astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ addons:
 
 env:
     global:
-        - PYTHON_VERSION=3.6
-        - NUMPY_VERSION=1.15
+        - PYTHON_VERSION=3.7
+        - NUMPY_VERSION=1.17
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES='git+https://github.com/dendrograms/astrodendro.git git+https://github.com/radio-astro-tools/spectral-cube.git'
+        - PIP_DEPENDENCIES='git+https://github.com/dendrograms/astrodendro.git git+https://github.com/radio-astro-tools/spectral-cube.git git+https://github.com/radio-astro-tools/radio-beam.git'
         - EVENT_TYPE='pull_request push'
 
         - CONDA_CHANNELS='astropy-ci-extras astropy'
@@ -46,7 +46,7 @@ matrix:
         # Do a coverage test.
         - os: linux
           env: SETUP_CMD='test --coverage'
-               PIP_DEPENDENCIES='emcee pyfftw git+https://github.com/dendrograms/astrodendro.git git+https://github.com/radio-astro-tools/spectral-cube.git'
+               PIP_DEPENDENCIES='emcee pyfftw git+https://github.com/dendrograms/astrodendro.git git+https://github.com/radio-astro-tools/spectral-cube.git git+https://github.com/radio-astro-tools/radio-beam.git'
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - os: linux
@@ -72,11 +72,11 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.13 ASTROPY_VERSION=LTS
-        - os: linux
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.14 ASTROPY_VERSION=LTS
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.14 ASTROPY_VERSION=LTS
         - os: linux
           env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.15 ASTROPY_VERSION=LTS
+        - os: linux
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.16 ASTROPY_VERSION=LTS
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES='git+https://github.com/dendrograms/astrodendro.git git+https://github.com/radio-astro-tools/spectral-cube.git git+https://github.com/radio-astro-tools/radio-beam.git'
+        - PIP_DEPENDENCIES='git+https://github.com/dendrograms/astrodendro.git git+https://github.com/radio-astro-tools/radio-beam.git git+https://github.com/radio-astro-tools/spectral-cube.git'
         - EVENT_TYPE='pull_request push'
 
         - CONDA_CHANNELS='astropy-ci-extras astropy'

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
         - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts NUMPY_VERSION=1.16
         - os: linux
           env: ASTROPY_VERSION=lts
 

--- a/turbustat/statistics/pca/width_estimate.py
+++ b/turbustat/statistics/pca/width_estimate.py
@@ -131,7 +131,11 @@ def WidthEstimate2D(inList, method='contour', noise_ACF=0,
         elif method == 'xinterpolate':
             warn("Error estimation not implemented for interpolation!")
             output, cov = fit_2D_gaussian(xmat, ymat, z)
-            aspect = output.y_stddev_0.value[0] / output.x_stddev_0.value[0]
+            try:
+                aspect = output.y_stddev_0.value[0] / output.x_stddev_0.value[0]
+            except IndexError:  # raised with astropy >v3.3 (current dev.)
+                aspect = output.y_stddev_0.value / output.x_stddev_0.value
+
             theta = output.theta_0.value[0]
             rmat = ((xmat * np.cos(theta) + ymat * np.sin(theta))**2 +
                     (-xmat * np.sin(theta) + ymat * np.cos(theta))**2 *

--- a/turbustat/statistics/pca/width_estimate.py
+++ b/turbustat/statistics/pca/width_estimate.py
@@ -341,7 +341,10 @@ def WidthEstimate1D(inList, method='walk-down'):
                 continue
 
             errors = np.sqrt(np.abs(fit_g.fit_info['param_cov'].diagonal()))
-            scales[idx] = np.abs(output.stddev.value[0]) * np.sqrt(2)
+            try:
+                scales[idx] = np.abs(output.stddev.value[0]) * np.sqrt(2)
+            except IndexError:  # raised with astropy >v3.3 (current dev.)
+                scales[idx] = np.abs(output.stddev.value) * np.sqrt(2)
             scale_errors[idx] = errors[-1] * np.sqrt(2)
         elif method == "walk-down":
             y /= y.max()

--- a/turbustat/statistics/pca/width_estimate.py
+++ b/turbustat/statistics/pca/width_estimate.py
@@ -133,10 +133,11 @@ def WidthEstimate2D(inList, method='contour', noise_ACF=0,
             output, cov = fit_2D_gaussian(xmat, ymat, z)
             try:
                 aspect = output.y_stddev_0.value[0] / output.x_stddev_0.value[0]
+                theta = output.theta_0.value[0]
             except IndexError:  # raised with astropy >v3.3 (current dev.)
                 aspect = output.y_stddev_0.value / output.x_stddev_0.value
+                theta = output.theta_0.value
 
-            theta = output.theta_0.value[0]
             rmat = ((xmat * np.cos(theta) + ymat * np.sin(theta))**2 +
                     (-xmat * np.sin(theta) + ymat * np.cos(theta))**2 *
                     aspect**2)**0.5

--- a/turbustat/statistics/scf/scf.py
+++ b/turbustat/statistics/scf/scf.py
@@ -4,7 +4,7 @@ from __future__ import print_function, absolute_import, division
 import numpy as np
 from astropy import units as u
 from astropy.wcs import WCS
-from astropy.extern.six import string_types
+from six import string_types
 import statsmodels.api as sm
 from warnings import warn
 from astropy.utils.console import ProgressBar

--- a/turbustat/tests/_testing_data.py
+++ b/turbustat/tests/_testing_data.py
@@ -99,10 +99,10 @@ dataset2 = props2.to_dict()
 # Load in saved comparison data.
 try:
     computed_data = np.load(os.path.join(turb_path, "data/checkVals.npz"),
-                            encoding='latin1')
+                            encoding='latin1', allow_pickle=True)
 
     computed_distances = np.load(os.path.join(turb_path,
                                               "data/computed_distances.npz"),
-                                 encoding='latin1')
+                                 encoding='latin1', allow_pickle=True)
 except IOError:
     warnings.warn("No checkVals or computed_distances files.")


### PR DESCRIPTION
`astropy.six.extern` was removed from the dev version of astropy.