### PR TITLE
Change the "average" 1D pspec operation

### DIFF
--- a/turbustat/statistics/psds.py
+++ b/turbustat/statistics/psds.py
@@ -10,7 +10,8 @@ from scipy.stats import t as t_dist
 
 def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
           logspacing=True, max_bin=None, min_bin=None, return_freqs=True,
-          theta_0=None, delta_theta=None, boot_iter=None):
+          theta_0=None, delta_theta=None, boot_iter=None,
+          mean_func=np.nanmean):
     '''
     Calculate the radial profile using scipy.stats.binned_statistic.
 
@@ -42,6 +43,9 @@ def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
     boot_iter : int, optional
         Number of bootstrap iterations for estimating the standard deviation
         in each bin. Require `return_stddev=True`.
+    mean_func : function, optional
+        Define the function used to create the 1D power spectrum. The default
+        is `np.nanmean`.
 
     Returns
     -------
@@ -128,7 +132,7 @@ def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
     ps1D, bin_edge, cts = binned_statistic(dist_arr[azim_mask].ravel(),
                                            psd2[azim_mask].ravel(),
                                            bins=bins,
-                                           statistic=np.nanmean)
+                                           statistic=mean_func)
 
     bin_cents = (bin_edge[1:] + bin_edge[:-1]) / 2.
 

--- a/turbustat/statistics/vca_vcs/vca.py
+++ b/turbustat/statistics/vca_vcs/vca.py
@@ -30,11 +30,13 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
         Physical distance to the region in the data.
     beam : `radio_beam.Beam`, optional
         Beam object for correcting for the effect of a finite beam.
-    channel_width : `~astropy.units.Quantity`, optional
+    channel_width : `~astropy.units.Quantity` or int, optional
         Set the width of channels to compute the VCA with. The channel width
         in the data is used by default. Given widths will be used to
-        spectrally down-sample the data before calculating the VCA. Up-sampling
-        to smaller channel sizes than the original is not supported.
+        spectrally down-sample the data before calculating the VCA. Given an
+        integer value, the spectral axis will be downsampled by the given
+        number of spectral channels. Up-sampling to smaller channel sizes
+        than the original is not supported.
     downsample_kwargs : dict, optional
         Passed to `~turbustat.statistics.vca_vca.slice_thickness.spectral_regrid_cube`.
     '''


### PR DESCRIPTION
All of the 1D pspec are azimuthal means over the 2D PSD. But a median or sigma-clipped mean could be useful for some data sets.

The function for the average can now be specified using:
```
import numpy as np
from turbustat.statistics import PowerSpectrum  # Or another pspec method
pspec = PowerSpectrum(hdu)  # Some already loaded FITS HDU
pspec.compute_pspec()
pspec.compute_radial_pspec(mean_func=np.nanmedian)
```
The default is to use `np.nanmean`.

Using the `run` function:
```
pspec.run(radial_pspec_kwargs={'mean_func': np.nanmedian})
```