### PR TITLE
Fix binned statistics calls

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -3,6 +3,7 @@ Version 1.2 (unreleased)
 
 Version 1.1 (2019-11-26)
 ------------------------
+* #227 - Fix `binned_statistic` calls for scipy 1.14 (checks for non-finite values).
 * #217 - Add pip install to docs. Clean-up setup script.
 
 Version 1.0 (2019-04-20)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,8 @@ MOCK_MODULES = ['sklearn', 'sklearn.metrics', 'sklearn.metrics.pairwise',
                 'spectral_cube.wcs_utils', "spectral_cube.cube_utils",
                 'spectral_cube.lower_dimensional_structures',
                 'spectral_cube.spectral_cube',
-                'emcee', 'skimage', 'skimage.measure']
+                'emcee', 'skimage', 'skimage.measure',
+                'seaborn']
 
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.Mock()

--- a/docs/tutorials/code_for_examples.py
+++ b/docs/tutorials/code_for_examples.py
@@ -1,486 +1,490 @@
 
-import os
-from os.path import join as osjoin
-import matplotlib.pyplot as plt
-import seaborn as sb
-import astropy.units as u
-from astropy.io import fits
-from spectral_cube import Projection
-import numpy as np
-
-from turbustat.simulator import make_extended
-
-from turbustat.io.sim_tools import create_fits_hdu
-
-from turbustat.statistics import PowerSpectrum
-
-# Use my default seaborn setting
-# sb.set(font='Times New Roman', style='ticks')
-# sb.set_context("poster", font_scale=1.0,
-#                rc={'figure.figsize': (11.7, 8.27)})
-
-sb.set(font='Sans-Serif', style='ticks')
-sb.set_context("paper", font_scale=1.)
-
-# For some reason, the figure size isn't getting updated by the context
-# change on my work desktop. Specify manually here
-plt.rcParams['figure.figsize'] = (9, 6.3)
-
-col_pal = sb.color_palette('colorblind')
-
-
-fig_path = 'images'
-
-# Choose which methods to run
-run_apod_examples = False  # applying_apodizing_functions.rst
-run_beamcorr_examples = False  # correcting_for_the_beam.rst
-run_plawfield_examples = False  # generating_test_data.rst
-run_missing_data_noise = False  # missing_data_noise.rst
-run_data_for_tutorials = False  # data_for_tutorials.rst
-
-if run_apod_examples:
-
-    from turbustat.statistics.apodizing_kernels import \
-        (CosineBellWindow, TukeyWindow, HanningWindow, SplitCosineBellWindow)
-
-    # Apodizing kernel
-
-    shape = (101, 101)
-    taper = HanningWindow()
-    data = taper(shape)
-
-    plt.subplot(121)
-    plt.imshow(data, cmap='viridis', origin='lower')
-    plt.colorbar()
-    plt.subplot(122)
-    plt.plot(data[shape[0] // 2])
-    plt.savefig(osjoin(fig_path, 'hanning.png'))
-    plt.close()
-
-    taper2 = CosineBellWindow(alpha=0.98)
-    data2 = taper2(shape)
-
-    plt.subplot(121)
-    plt.imshow(data2, cmap='viridis', origin='lower')
-    plt.colorbar()
-    plt.subplot(122)
-    plt.plot(data2[shape[0] // 2])
-    plt.savefig(osjoin(fig_path, 'cosine.png'))
-    plt.close()
-
-    taper3 = SplitCosineBellWindow(alpha=0.3, beta=0.8)
-    data3 = taper3(shape)
-
-    plt.subplot(121)
-    plt.imshow(data3, cmap='viridis', origin='lower')
-    plt.colorbar()
-    plt.subplot(122)
-    plt.plot(data3[shape[0] // 2])
-    plt.savefig(osjoin(fig_path, 'splitcosine.png'))
-    plt.close()
-
-    taper4 = TukeyWindow(alpha=0.3)
-    data4 = taper4(shape)
-
-    plt.subplot(121)
-    plt.imshow(data4, cmap='viridis', origin='lower')
-    plt.colorbar()
-    plt.subplot(122)
-    plt.plot(data4[shape[0] // 2])
-    plt.savefig(osjoin(fig_path, 'tukey.png'))
-    plt.close()
-
-    plt.plot(data[shape[0] // 2], label='Hanning')
-    plt.plot(data2[shape[0] // 2], label='Cosine')
-    plt.plot(data3[shape[0] // 2], label='Split Cosine')
-    plt.plot(data4[shape[0] // 2], label='Tukey')
-    plt.legend(frameon=True)
-    plt.savefig(osjoin(fig_path, '1d_apods.png'))
-    plt.close()
-
-    freqs = np.fft.rfftfreq(shape[0])
-    plt.loglog(freqs, np.abs(np.fft.rfft(data[shape[0] // 2]))**2, label='Hanning')
-    plt.loglog(freqs, np.abs(np.fft.rfft(data2[shape[0] // 2]))**2, label='Cosine')
-    plt.loglog(freqs, np.abs(np.fft.rfft(data3[shape[0] // 2]))**2, label='Split Cosine')
-    plt.loglog(freqs, np.abs(np.fft.rfft(data4[shape[0] // 2]))**2, label='Tukey')
-    plt.legend(frameon=True)
-    plt.xlabel("Freq. (1 / pix)")
-    plt.ylabel("Power")
-    plt.savefig(osjoin(fig_path, '1d_apods_pspec.png'))
-    plt.close()
-
-    # Example of 2D Tukey power-spectrum
-    plt.imshow(np.log10(np.fft.fftshift(np.abs(np.fft.fft2(data4))**2)))
-    plt.savefig(osjoin(fig_path, '2d_tukey_pspec.png'))
-    plt.close()
-
-    # This is easier to show with a red noise image due to the limited
-    # inertial range in the sim data.
-    rnoise_img = make_extended(256, powerlaw=3.)
-
-    pixel_scale = 3 * u.arcsec
-    beamfwhm = 3 * u.arcsec
-    imshape = rnoise_img.shape
-    restfreq = 1.4 * u.GHz
-    bunit = u.K
-
-    plaw_hdu = create_fits_hdu(rnoise_img, pixel_scale, beamfwhm, imshape,
-                               restfreq, bunit)
-
-    plt.imshow(plaw_hdu.data, cmap='viridis')
-    plt.savefig(osjoin(fig_path, "rednoise_slope3_img.png"))
-    plt.close()
-
-    pspec = PowerSpectrum(plaw_hdu)
-    pspec.run(verbose=True, radial_pspec_kwargs={'binsize': 1.0},
-              fit_kwargs={'weighted_fit': False}, fit_2D=False,
-              low_cut=1. / (60 * u.pix),
-              save_name=osjoin(fig_path, "rednoise_pspec_slope3.png"))
-
-    pspec_partial = PowerSpectrum(rnoise_img[:128, :128], header=plaw_hdu.header)
-    pspec_partial.run(verbose=False, fit_2D=False, low_cut=1 / (60. * u.pix))
-    plt.imshow(np.log10(pspec_partial.ps2D))
-    plt.savefig(osjoin(fig_path, "rednoise_pspec_slope3_2D_slicecross.png"))
-    plt.close()
-
-    pspec2 = PowerSpectrum(plaw_hdu)
-    pspec2.run(verbose=False, radial_pspec_kwargs={'binsize': 1.0},
-               fit_kwargs={'weighted_fit': False}, fit_2D=False,
-               low_cut=1. / (60 * u.pix),
-               apodize_kernel='hanning',)
-
-    pspec3 = PowerSpectrum(plaw_hdu)
-    pspec3.run(verbose=False, radial_pspec_kwargs={'binsize': 1.0},
-               fit_kwargs={'weighted_fit': False}, fit_2D=False,
-               low_cut=1. / (60 * u.pix),
-               apodize_kernel='cosinebell', alpha=0.98,)
-
-    pspec4 = PowerSpectrum(plaw_hdu)
-    pspec4.run(verbose=False, radial_pspec_kwargs={'binsize': 1.0},
-               fit_kwargs={'weighted_fit': False}, fit_2D=False,
-               low_cut=1. / (60 * u.pix),
-               apodize_kernel='splitcosinebell', alpha=0.3, beta=0.8)
-
-    pspec5 = PowerSpectrum(plaw_hdu)
-    pspec5.run(verbose=False, radial_pspec_kwargs={'binsize': 1.0},
-               fit_kwargs={'weighted_fit': False}, fit_2D=False,
-               low_cut=1. / (60 * u.pix),
-               apodize_kernel='tukey', alpha=0.3)
-
-    # Overplot all of the to demonstrate affect on large-scales.
-
-    pspec.plot_fit(color=col_pal[0], label='Original')
-    pspec2.plot_fit(color=col_pal[1], label='Hanning')
-    pspec3.plot_fit(color=col_pal[2], label='CosineBell')
-    pspec4.plot_fit(color=col_pal[3], label='SplitCosineBell')
-    pspec5.plot_fit(color=col_pal[4], label='Tukey')
-    plt.legend(frameon=True, loc='lower left')
-    plt.ylim([-2, 7.5])
-    plt.tight_layout()
-    plt.savefig(osjoin(fig_path, "rednoise_pspec_slope3_apod_comparisons.png"))
-    plt.close()
-
-    print("Original: {0:.2f} \nHanning: {1:.2f} \nCosineBell: {2:.2f} \n"
-          "SplitCosineBell: {3:.2f} \nTukey: {4:.2f}"
-          .format(pspec.slope, pspec2.slope, pspec3.slope, pspec4.slope,
-                  pspec5.slope))
-
-if run_beamcorr_examples:
-
-    from radio_beam import Beam
-
-    rnoise_img = make_extended(256, powerlaw=3.)
-
-    pixel_scale = 3 * u.arcsec
-    beamfwhm = 3 * u.arcsec
-    imshape = rnoise_img.shape
-    restfreq = 1.4 * u.GHz
-    bunit = u.K
-
-    plaw_hdu = create_fits_hdu(rnoise_img, pixel_scale, beamfwhm, imshape,
-                               restfreq, bunit)
-
-    pspec = PowerSpectrum(plaw_hdu)
-    pspec.run(verbose=True, radial_pspec_kwargs={'binsize': 1.0},
-              fit_kwargs={'weighted_fit': False}, fit_2D=False,
-              low_cut=1. / (60 * u.pix),
-              save_name=osjoin(fig_path, "rednoise_pspec_slope3.png"))
-
-    pencil_beam = Beam(0 * u.deg)
-    plaw_proj = Projection.from_hdu(plaw_hdu)
-    plaw_proj = plaw_proj.with_beam(pencil_beam)
-
-    new_beam = Beam(3 * plaw_hdu.header['CDELT2'] * u.deg)
-    plaw_conv = plaw_proj.convolve_to(new_beam)
-
-    plaw_conv.quicklook()
-    plt.savefig('images/rednoise_slope3_img_smoothed.png')
-    plt.close()
-
-    pspec2 = PowerSpectrum(plaw_conv)
-    pspec2.run(verbose=True, xunit=u.pix**-1, fit_2D=False,
-               low_cut=0.025 / u.pix, high_cut=0.1 / u.pix,
-               radial_pspec_kwargs={'binsize': 1.0},
-               apodize_kernel='tukey')
-    plt.axvline(np.log10(1 / 3.), color=col_pal[3], linewidth=8, alpha=0.8,
-                zorder=1)
-    plt.savefig("images/rednoise_pspec_slope3_smoothed.png")
-    plt.close()
-
-    pspec3 = PowerSpectrum(plaw_conv)
-    pspec3.run(verbose=True, xunit=u.pix**-1, fit_2D=False,
-               low_cut=0.025 / u.pix, high_cut=0.4 / u.pix,
-               apodize_kernel='tukey', beam_correct=True)
-    plt.axvline(np.log10(1 / 3.), color=col_pal[3], linewidth=8, alpha=0.8,
-                zorder=1)
-    plt.savefig("images/rednoise_pspec_slope3_smoothed_beamcorr.png")
-    plt.close()
-
-    # Overplot original, smooth, corrected, etc..
-
-    pspec.plot_fit(color=col_pal[0], label='Original')
-    pspec2.plot_fit(color=col_pal[1], label='Smoothed')
-    pspec3.plot_fit(color=col_pal[2], label='Beam-Corrected')
-    plt.legend(frameon=True, loc='lower left')
-    plt.axvline(np.log10(1 / 3.), color=col_pal[3], linewidth=8, alpha=0.8, zorder=-1)
-    plt.ylim([-2, 7.5])
-    plt.tight_layout()
-    plt.savefig("images/rednoise_pspec_slope3_beam_comparisons.png")
-    plt.close()
-
-
-if run_plawfield_examples:
-
-    # Use the same settings as above for the isotropic case
-
-    rnoise_img = make_extended(256, powerlaw=3.)
-
-    pixel_scale = 3 * u.arcsec
-    beamfwhm = 3 * u.arcsec
-    imshape = rnoise_img.shape
-    restfreq = 1.4 * u.GHz
-    bunit = u.K
-
-    # plaw_hdu = create_fits_hdu(rnoise_img, pixel_scale, beamfwhm, imshape,
-    #                            restfreq, bunit)
-
-    # pspec = PowerSpectrum(plaw_hdu)
-    # pspec.run(verbose=True, radial_pspec_kwargs={'binsize': 1.0},
-    #           fit_kwargs={'weighted_fit': False}, fit_2D=False,
-    #           low_cut=1. / (60 * u.pix),
-    #           save_name=osjoin(fig_path, "rednoise_pspec_slope3.png"))
-
-    # 2D anisotropic
-
-    rnoise_img = make_extended(256, powerlaw=3., ellip=0.5, theta=45 * u.deg)
-
-    plt.imshow(rnoise_img)
-    plt.savefig(osjoin(fig_path, "rednoise_slope3_ellip_05_theta_45.png"))
-    plt.close()
-
-    plaw_hdu = create_fits_hdu(rnoise_img, pixel_scale, beamfwhm, imshape,
-                               restfreq, bunit)
-
-    pspec = PowerSpectrum(plaw_hdu)
-    pspec.run(verbose=True, radial_pspec_kwargs={'binsize': 1.0},
-              fit_kwargs={'weighted_fit': False}, fit_2D=True,
-              low_cut=1. / (60 * u.pix),
-              save_name=osjoin(fig_path, "rednoise_pspec_slope3_ellip_05_theta_45.png"))
-
-    # 3D
-
-    from turbustat.simulator import make_3dfield
-
-    threeD_field = make_3dfield(128, powerlaw=3.)
-
-    plt.figure(figsize=[10, 3])
-    plt.subplot(131)
-    plt.imshow(threeD_field.mean(0), origin='lower')
-    plt.subplot(132)
-    plt.imshow(threeD_field.mean(1), origin='lower')
-    plt.subplot(133)
-    plt.imshow(threeD_field.mean(2), origin='lower')
-    plt.tight_layout()
-    plt.savefig(osjoin(fig_path, "rednoise_3D_slope3_projs.png"))
-    plt.close()
-
-    # PPV cube
-
-    from turbustat.simulator import make_ppv
-
-    velocity = make_3dfield(32, powerlaw=4., amp=1.,
-                            randomseed=98734) * u.km / u.s
-
-    # Deal with negative density values.
-    density = make_3dfield(32, powerlaw=3., amp=1.,
-                           randomseed=328764) * u.cm**-3
-    density += density.std()
-    density[density.value < 0.] = 0. * u.cm**-3
-
-    T = 100 * u.K
-
-    cube_hdu = make_ppv(velocity, density, los_axis=0,
-                        vel_disp=np.std(velocity, axis=0).mean(),
-                        T=T, chan_width=0.5 * u.km / u.s,
-                        v_min=-20 * u.km / u.s, v_max=20 * u.km / u.s)
-
-    from spectral_cube import SpectralCube
-
-    cube = SpectralCube.read(cube_hdu)
-
-    cube.moment0().quicklook()
-    plt.colorbar()
-    plt.savefig(osjoin(fig_path, "ppv_mom0.png"))
-    plt.close()
-
-    cube.moment1().quicklook()
-    plt.colorbar()
-    plt.savefig(osjoin(fig_path, "ppv_mom1.png"))
-    plt.close()
-
-    cube.mean(axis=(1, 2)).quicklook()
-    plt.savefig(osjoin(fig_path, "ppv_mean_spec.png"))
-    plt.close()
-
-if run_missing_data_noise:
-
-    from turbustat.statistics import PowerSpectrum, DeltaVariance
-
-    img = make_extended(256, powerlaw=3., randomseed=54398493)
-
-    # Now shuffle so the peak is near the centre
-    img = np.roll(img, (128, -30), (0, 1))
-
-    img -= img.min()
-
-    plt.imshow(img, origin='lower')
-    plt.colorbar()
-    plt.tight_layout()
-    plt.savefig(osjoin(fig_path, 'missing_data_image.png'))
-    plt.close()
-
-    # Show image in the tutorial
-
-    pspec = PowerSpectrum(fits.PrimaryHDU(img))
-    pspec.run(verbose=True)
-    plt.savefig(osjoin(fig_path, 'missing_data_pspec.png'))
-    plt.close()
-
-    delvar = DeltaVariance(fits.PrimaryHDU(img))
-    delvar.run(verbose=True)
-    plt.savefig(osjoin(fig_path, 'missing_data_delvar.png'))
-    plt.close()
-
-    # Mask some of the data out
-
-    masked_img = img.copy()
-    masked_img[masked_img < np.percentile(img, 25)] = np.NaN
-
-    plt.imshow(masked_img, origin='lower')
-    plt.colorbar()
-    plt.tight_layout()
-    plt.savefig(osjoin(fig_path, 'missing_data_image_masked.png'))
-    plt.close()
-
-    pspec_masked = PowerSpectrum(fits.PrimaryHDU(masked_img))
-    pspec_masked.run(verbose=True, high_cut=10**-1.25 / u.pix)
-    plt.savefig(osjoin(fig_path, 'missing_data_pspec_masked.png'))
-    plt.close()
-
-    # Just masked
-    delvar_masked = DeltaVariance(fits.PrimaryHDU(masked_img))
-    delvar_masked.run(verbose=True, xlow=2 * u.pix, xhigh=50 * u.pix)
-    plt.savefig(osjoin(fig_path, 'missing_data_delvar_masked.png'))
-    plt.close()
-
-    # What happens if we just pad that image with empty values
-
-    # From:
-    # https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.pad.html
-    def pad_with(vector, pad_width, iaxis, kwargs):
-        pad_value = kwargs.get('padder', 0.)
-        vector[:pad_width[0]] = pad_value
-        vector[-pad_width[1]:] = pad_value
-        return vector
-
-    padded_masked_img = np.pad(masked_img, 128, pad_with, padder=np.NaN)
-
-    from scipy import ndimage as nd
-    labs, num = nd.label(np.isfinite(padded_masked_img), np.ones((3, 3)))
-    # Keep the largest regions
-    padded_masked_img[np.where(labs > 1)] = np.NaN
-
-    plt.imshow(padded_masked_img, origin='lower')
-    plt.colorbar()
-    plt.tight_layout()
-    plt.savefig(osjoin(fig_path, 'missing_data_image_masked_padded.png'))
-    plt.close()
-
-    pspec_masked_pad = PowerSpectrum(fits.PrimaryHDU(padded_masked_img))
-    pspec_masked_pad.run(verbose=True, high_cut=10**-1.25 / u.pix)
-    plt.savefig(osjoin(fig_path, 'missing_data_pspec_masked_pad.png'))
-    plt.close()
-
-    delvar_masked_padded = DeltaVariance(fits.PrimaryHDU(padded_masked_img))
-    delvar_masked_padded.run(verbose=True, xlow=2 * u.pix, xhigh=70 * u.pix)
-    plt.savefig(osjoin(fig_path, 'missing_data_delvar_masked_pad.png'))
-    plt.close()
-
-    noise_rms = 1.
-    noisy_img = img + np.random.normal(0., noise_rms, img.shape)
-
-    plt.imshow(noisy_img, origin='lower')
-    plt.colorbar()
-    plt.tight_layout()
-    plt.savefig(osjoin(fig_path, 'missing_data_image_noisy.png'))
-    plt.close()
-
-    pspec_noisy = PowerSpectrum(fits.PrimaryHDU(noisy_img))
-    pspec_noisy.run(verbose=True, high_cut=10**-1.2 / u.pix)
-    plt.savefig(osjoin(fig_path, 'missing_data_pspec_noisy.png'))
-    plt.close()
-
-    delvar_noisy = DeltaVariance(fits.PrimaryHDU(noisy_img))
-    delvar_noisy.run(verbose=True, xlow=10 * u.pix, xhigh=70 * u.pix)
-    plt.savefig(osjoin(fig_path, 'missing_data_delvar_noisy.png'))
-    plt.close()
-
-    # noisy_masked_img = noisy_img.copy()
-    # noisy_masked_img[noisy_masked_img < 5 * noise_rms] = np.NaN
-
-    # pspec_noisy_masked = PowerSpectrum(fits.PrimaryHDU(noisy_masked_img))
-    # pspec_noisy_masked.run(verbose=True, high_cut=10**-1.2 / u.pix)
-    # plt.savefig(osjoin(fig_path, 'missing_data_pspec_noisy.png'))
-    # plt.close()
-
-    # delvar_noisy_masked = DeltaVariance(fits.PrimaryHDU(noisy_masked_img))
-    # delvar_noisy_masked.run(verbose=True, xlow=10 * u.pix, xhigh=70 * u.pix)
-
-if run_data_for_tutorials:
-
-    # Make moment 0 maps for the tutorial data
-
-    fid_mom0 = fits.open("../../testingdata/Fiducial0_flatrho_0021_00_radmc_moment0.fits")[0]
-    des_mom0 = fits.open("../../testingdata/Design4_flatrho_0021_00_radmc_moment0.fits")[0]
-
-    from mpl_toolkits.axes_grid import make_axes_locatable
-
-    ax = plt.subplot(121)
-    im1 = plt.imshow(fid_mom0.data / 1000., origin='lower')
-    ax.set_title("Fiducial")
-    divider = make_axes_locatable(ax)
-    cax = divider.append_axes("right", "5%", pad="3%")
-    cb = plt.colorbar(im1, cax=cax)
-
-    ax2 = plt.subplot(122)
-    im2 = plt.imshow(des_mom0.data / 1000., origin='lower')
-    ax2.set_title("Design")
-    divider = make_axes_locatable(ax2)
-    cax2 = divider.append_axes("right", "5%", pad="3%")
-    cb2 = plt.colorbar(im2, cax=cax2)
-    cb2.set_label(r"K km s$^{-1}$")
-
-    plt.tight_layout()
-
-    plt.savefig(osjoin(fig_path, "design_fiducial_moment0.png"))
-    plt.close()
+RUN_CODE = False
+
+if RUN_CODE:
+
+    import os
+    from os.path import join as osjoin
+    import matplotlib.pyplot as plt
+    # import seaborn as sb
+    import astropy.units as u
+    from astropy.io import fits
+    from spectral_cube import Projection
+    import numpy as np
+
+    from turbustat.simulator import make_extended
+
+    from turbustat.io.sim_tools import create_fits_hdu
+
+    from turbustat.statistics import PowerSpectrum
+
+    # Use my default seaborn setting
+    # sb.set(font='Times New Roman', style='ticks')
+    # sb.set_context("poster", font_scale=1.0,
+    #                rc={'figure.figsize': (11.7, 8.27)})
+
+    sb.set(font='Sans-Serif', style='ticks')
+    sb.set_context("paper", font_scale=1.)
+
+    # For some reason, the figure size isn't getting updated by the context
+    # change on my work desktop. Specify manually here
+    plt.rcParams['figure.figsize'] = (9, 6.3)
+
+    col_pal = sb.color_palette('colorblind')
+
+
+    fig_path = 'images'
+
+    # Choose which methods to run
+    run_apod_examples = False  # applying_apodizing_functions.rst
+    run_beamcorr_examples = False  # correcting_for_the_beam.rst
+    run_plawfield_examples = False  # generating_test_data.rst
+    run_missing_data_noise = False  # missing_data_noise.rst
+    run_data_for_tutorials = False  # data_for_tutorials.rst
+
+    if run_apod_examples:
+
+        from turbustat.statistics.apodizing_kernels import \
+            (CosineBellWindow, TukeyWindow, HanningWindow, SplitCosineBellWindow)
+
+        # Apodizing kernel
+
+        shape = (101, 101)
+        taper = HanningWindow()
+        data = taper(shape)
+
+        plt.subplot(121)
+        plt.imshow(data, cmap='viridis', origin='lower')
+        plt.colorbar()
+        plt.subplot(122)
+        plt.plot(data[shape[0] // 2])
+        plt.savefig(osjoin(fig_path, 'hanning.png'))
+        plt.close()
+
+        taper2 = CosineBellWindow(alpha=0.98)
+        data2 = taper2(shape)
+
+        plt.subplot(121)
+        plt.imshow(data2, cmap='viridis', origin='lower')
+        plt.colorbar()
+        plt.subplot(122)
+        plt.plot(data2[shape[0] // 2])
+        plt.savefig(osjoin(fig_path, 'cosine.png'))
+        plt.close()
+
+        taper3 = SplitCosineBellWindow(alpha=0.3, beta=0.8)
+        data3 = taper3(shape)
+
+        plt.subplot(121)
+        plt.imshow(data3, cmap='viridis', origin='lower')
+        plt.colorbar()
+        plt.subplot(122)
+        plt.plot(data3[shape[0] // 2])
+        plt.savefig(osjoin(fig_path, 'splitcosine.png'))
+        plt.close()
+
+        taper4 = TukeyWindow(alpha=0.3)
+        data4 = taper4(shape)
+
+        plt.subplot(121)
+        plt.imshow(data4, cmap='viridis', origin='lower')
+        plt.colorbar()
+        plt.subplot(122)
+        plt.plot(data4[shape[0] // 2])
+        plt.savefig(osjoin(fig_path, 'tukey.png'))
+        plt.close()
+
+        plt.plot(data[shape[0] // 2], label='Hanning')
+        plt.plot(data2[shape[0] // 2], label='Cosine')
+        plt.plot(data3[shape[0] // 2], label='Split Cosine')
+        plt.plot(data4[shape[0] // 2], label='Tukey')
+        plt.legend(frameon=True)
+        plt.savefig(osjoin(fig_path, '1d_apods.png'))
+        plt.close()
+
+        freqs = np.fft.rfftfreq(shape[0])
+        plt.loglog(freqs, np.abs(np.fft.rfft(data[shape[0] // 2]))**2, label='Hanning')
+        plt.loglog(freqs, np.abs(np.fft.rfft(data2[shape[0] // 2]))**2, label='Cosine')
+        plt.loglog(freqs, np.abs(np.fft.rfft(data3[shape[0] // 2]))**2, label='Split Cosine')
+        plt.loglog(freqs, np.abs(np.fft.rfft(data4[shape[0] // 2]))**2, label='Tukey')
+        plt.legend(frameon=True)
+        plt.xlabel("Freq. (1 / pix)")
+        plt.ylabel("Power")
+        plt.savefig(osjoin(fig_path, '1d_apods_pspec.png'))
+        plt.close()
+
+        # Example of 2D Tukey power-spectrum
+        plt.imshow(np.log10(np.fft.fftshift(np.abs(np.fft.fft2(data4))**2)))
+        plt.savefig(osjoin(fig_path, '2d_tukey_pspec.png'))
+        plt.close()
+
+        # This is easier to show with a red noise image due to the limited
+        # inertial range in the sim data.
+        rnoise_img = make_extended(256, powerlaw=3.)
+
+        pixel_scale = 3 * u.arcsec
+        beamfwhm = 3 * u.arcsec
+        imshape = rnoise_img.shape
+        restfreq = 1.4 * u.GHz
+        bunit = u.K
+
+        plaw_hdu = create_fits_hdu(rnoise_img, pixel_scale, beamfwhm, imshape,
+                                   restfreq, bunit)
+
+        plt.imshow(plaw_hdu.data, cmap='viridis')
+        plt.savefig(osjoin(fig_path, "rednoise_slope3_img.png"))
+        plt.close()
+
+        pspec = PowerSpectrum(plaw_hdu)
+        pspec.run(verbose=True, radial_pspec_kwargs={'binsize': 1.0},
+                  fit_kwargs={'weighted_fit': False}, fit_2D=False,
+                  low_cut=1. / (60 * u.pix),
+                  save_name=osjoin(fig_path, "rednoise_pspec_slope3.png"))
+
+        pspec_partial = PowerSpectrum(rnoise_img[:128, :128], header=plaw_hdu.header)
+        pspec_partial.run(verbose=False, fit_2D=False, low_cut=1 / (60. * u.pix))
+        plt.imshow(np.log10(pspec_partial.ps2D))
+        plt.savefig(osjoin(fig_path, "rednoise_pspec_slope3_2D_slicecross.png"))
+        plt.close()
+
+        pspec2 = PowerSpectrum(plaw_hdu)
+        pspec2.run(verbose=False, radial_pspec_kwargs={'binsize': 1.0},
+                   fit_kwargs={'weighted_fit': False}, fit_2D=False,
+                   low_cut=1. / (60 * u.pix),
+                   apodize_kernel='hanning',)
+
+        pspec3 = PowerSpectrum(plaw_hdu)
+        pspec3.run(verbose=False, radial_pspec_kwargs={'binsize': 1.0},
+                   fit_kwargs={'weighted_fit': False}, fit_2D=False,
+                   low_cut=1. / (60 * u.pix),
+                   apodize_kernel='cosinebell', alpha=0.98,)
+
+        pspec4 = PowerSpectrum(plaw_hdu)
+        pspec4.run(verbose=False, radial_pspec_kwargs={'binsize': 1.0},
+                   fit_kwargs={'weighted_fit': False}, fit_2D=False,
+                   low_cut=1. / (60 * u.pix),
+                   apodize_kernel='splitcosinebell', alpha=0.3, beta=0.8)
+
+        pspec5 = PowerSpectrum(plaw_hdu)
+        pspec5.run(verbose=False, radial_pspec_kwargs={'binsize': 1.0},
+                   fit_kwargs={'weighted_fit': False}, fit_2D=False,
+                   low_cut=1. / (60 * u.pix),
+                   apodize_kernel='tukey', alpha=0.3)
+
+        # Overplot all of the to demonstrate affect on large-scales.
+
+        pspec.plot_fit(color=col_pal[0], label='Original')
+        pspec2.plot_fit(color=col_pal[1], label='Hanning')
+        pspec3.plot_fit(color=col_pal[2], label='CosineBell')
+        pspec4.plot_fit(color=col_pal[3], label='SplitCosineBell')
+        pspec5.plot_fit(color=col_pal[4], label='Tukey')
+        plt.legend(frameon=True, loc='lower left')
+        plt.ylim([-2, 7.5])
+        plt.tight_layout()
+        plt.savefig(osjoin(fig_path, "rednoise_pspec_slope3_apod_comparisons.png"))
+        plt.close()
+
+        print("Original: {0:.2f} \nHanning: {1:.2f} \nCosineBell: {2:.2f} \n"
+              "SplitCosineBell: {3:.2f} \nTukey: {4:.2f}"
+              .format(pspec.slope, pspec2.slope, pspec3.slope, pspec4.slope,
+                      pspec5.slope))
+
+    if run_beamcorr_examples:
+
+        from radio_beam import Beam
+
+        rnoise_img = make_extended(256, powerlaw=3.)
+
+        pixel_scale = 3 * u.arcsec
+        beamfwhm = 3 * u.arcsec
+        imshape = rnoise_img.shape
+        restfreq = 1.4 * u.GHz
+        bunit = u.K
+
+        plaw_hdu = create_fits_hdu(rnoise_img, pixel_scale, beamfwhm, imshape,
+                                   restfreq, bunit)
+
+        pspec = PowerSpectrum(plaw_hdu)
+        pspec.run(verbose=True, radial_pspec_kwargs={'binsize': 1.0},
+                  fit_kwargs={'weighted_fit': False}, fit_2D=False,
+                  low_cut=1. / (60 * u.pix),
+                  save_name=osjoin(fig_path, "rednoise_pspec_slope3.png"))
+
+        pencil_beam = Beam(0 * u.deg)
+        plaw_proj = Projection.from_hdu(plaw_hdu)
+        plaw_proj = plaw_proj.with_beam(pencil_beam)
+
+        new_beam = Beam(3 * plaw_hdu.header['CDELT2'] * u.deg)
+        plaw_conv = plaw_proj.convolve_to(new_beam)
+
+        plaw_conv.quicklook()
+        plt.savefig('images/rednoise_slope3_img_smoothed.png')
+        plt.close()
+
+        pspec2 = PowerSpectrum(plaw_conv)
+        pspec2.run(verbose=True, xunit=u.pix**-1, fit_2D=False,
+                   low_cut=0.025 / u.pix, high_cut=0.1 / u.pix,
+                   radial_pspec_kwargs={'binsize': 1.0},
+                   apodize_kernel='tukey')
+        plt.axvline(np.log10(1 / 3.), color=col_pal[3], linewidth=8, alpha=0.8,
+                    zorder=1)
+        plt.savefig("images/rednoise_pspec_slope3_smoothed.png")
+        plt.close()
+
+        pspec3 = PowerSpectrum(plaw_conv)
+        pspec3.run(verbose=True, xunit=u.pix**-1, fit_2D=False,
+                   low_cut=0.025 / u.pix, high_cut=0.4 / u.pix,
+                   apodize_kernel='tukey', beam_correct=True)
+        plt.axvline(np.log10(1 / 3.), color=col_pal[3], linewidth=8, alpha=0.8,
+                    zorder=1)
+        plt.savefig("images/rednoise_pspec_slope3_smoothed_beamcorr.png")
+        plt.close()
+
+        # Overplot original, smooth, corrected, etc..
+
+        pspec.plot_fit(color=col_pal[0], label='Original')
+        pspec2.plot_fit(color=col_pal[1], label='Smoothed')
+        pspec3.plot_fit(color=col_pal[2], label='Beam-Corrected')
+        plt.legend(frameon=True, loc='lower left')
+        plt.axvline(np.log10(1 / 3.), color=col_pal[3], linewidth=8, alpha=0.8, zorder=-1)
+        plt.ylim([-2, 7.5])
+        plt.tight_layout()
+        plt.savefig("images/rednoise_pspec_slope3_beam_comparisons.png")
+        plt.close()
+
+
+    if run_plawfield_examples:
+
+        # Use the same settings as above for the isotropic case
+
+        rnoise_img = make_extended(256, powerlaw=3.)
+
+        pixel_scale = 3 * u.arcsec
+        beamfwhm = 3 * u.arcsec
+        imshape = rnoise_img.shape
+        restfreq = 1.4 * u.GHz
+        bunit = u.K
+
+        # plaw_hdu = create_fits_hdu(rnoise_img, pixel_scale, beamfwhm, imshape,
+        #                            restfreq, bunit)
+
+        # pspec = PowerSpectrum(plaw_hdu)
+        # pspec.run(verbose=True, radial_pspec_kwargs={'binsize': 1.0},
+        #           fit_kwargs={'weighted_fit': False}, fit_2D=False,
+        #           low_cut=1. / (60 * u.pix),
+        #           save_name=osjoin(fig_path, "rednoise_pspec_slope3.png"))
+
+        # 2D anisotropic
+
+        rnoise_img = make_extended(256, powerlaw=3., ellip=0.5, theta=45 * u.deg)
+
+        plt.imshow(rnoise_img)
+        plt.savefig(osjoin(fig_path, "rednoise_slope3_ellip_05_theta_45.png"))
+        plt.close()
+
+        plaw_hdu = create_fits_hdu(rnoise_img, pixel_scale, beamfwhm, imshape,
+                                   restfreq, bunit)
+
+        pspec = PowerSpectrum(plaw_hdu)
+        pspec.run(verbose=True, radial_pspec_kwargs={'binsize': 1.0},
+                  fit_kwargs={'weighted_fit': False}, fit_2D=True,
+                  low_cut=1. / (60 * u.pix),
+                  save_name=osjoin(fig_path, "rednoise_pspec_slope3_ellip_05_theta_45.png"))
+
+        # 3D
+
+        from turbustat.simulator import make_3dfield
+
+        threeD_field = make_3dfield(128, powerlaw=3.)
+
+        plt.figure(figsize=[10, 3])
+        plt.subplot(131)
+        plt.imshow(threeD_field.mean(0), origin='lower')
+        plt.subplot(132)
+        plt.imshow(threeD_field.mean(1), origin='lower')
+        plt.subplot(133)
+        plt.imshow(threeD_field.mean(2), origin='lower')
+        plt.tight_layout()
+        plt.savefig(osjoin(fig_path, "rednoise_3D_slope3_projs.png"))
+        plt.close()
+
+        # PPV cube
+
+        from turbustat.simulator import make_ppv
+
+        velocity = make_3dfield(32, powerlaw=4., amp=1.,
+                                randomseed=98734) * u.km / u.s
+
+        # Deal with negative density values.
+        density = make_3dfield(32, powerlaw=3., amp=1.,
+                               randomseed=328764) * u.cm**-3
+        density += density.std()
+        density[density.value < 0.] = 0. * u.cm**-3
+
+        T = 100 * u.K
+
+        cube_hdu = make_ppv(velocity, density, los_axis=0,
+                            vel_disp=np.std(velocity, axis=0).mean(),
+                            T=T, chan_width=0.5 * u.km / u.s,
+                            v_min=-20 * u.km / u.s, v_max=20 * u.km / u.s)
+
+        from spectral_cube import SpectralCube
+
+        cube = SpectralCube.read(cube_hdu)
+
+        cube.moment0().quicklook()
+        plt.colorbar()
+        plt.savefig(osjoin(fig_path, "ppv_mom0.png"))
+        plt.close()
+
+        cube.moment1().quicklook()
+        plt.colorbar()
+        plt.savefig(osjoin(fig_path, "ppv_mom1.png"))
+        plt.close()
+
+        cube.mean(axis=(1, 2)).quicklook()
+        plt.savefig(osjoin(fig_path, "ppv_mean_spec.png"))
+        plt.close()
+
+    if run_missing_data_noise:
+
+        from turbustat.statistics import PowerSpectrum, DeltaVariance
+
+        img = make_extended(256, powerlaw=3., randomseed=54398493)
+
+        # Now shuffle so the peak is near the centre
+        img = np.roll(img, (128, -30), (0, 1))
+
+        img -= img.min()
+
+        plt.imshow(img, origin='lower')
+        plt.colorbar()
+        plt.tight_layout()
+        plt.savefig(osjoin(fig_path, 'missing_data_image.png'))
+        plt.close()
+
+        # Show image in the tutorial
+
+        pspec = PowerSpectrum(fits.PrimaryHDU(img))
+        pspec.run(verbose=True)
+        plt.savefig(osjoin(fig_path, 'missing_data_pspec.png'))
+        plt.close()
+
+        delvar = DeltaVariance(fits.PrimaryHDU(img))
+        delvar.run(verbose=True)
+        plt.savefig(osjoin(fig_path, 'missing_data_delvar.png'))
+        plt.close()
+
+        # Mask some of the data out
+
+        masked_img = img.copy()
+        masked_img[masked_img < np.percentile(img, 25)] = np.NaN
+
+        plt.imshow(masked_img, origin='lower')
+        plt.colorbar()
+        plt.tight_layout()
+        plt.savefig(osjoin(fig_path, 'missing_data_image_masked.png'))
+        plt.close()
+
+        pspec_masked = PowerSpectrum(fits.PrimaryHDU(masked_img))
+        pspec_masked.run(verbose=True, high_cut=10**-1.25 / u.pix)
+        plt.savefig(osjoin(fig_path, 'missing_data_pspec_masked.png'))
+        plt.close()
+
+        # Just masked
+        delvar_masked = DeltaVariance(fits.PrimaryHDU(masked_img))
+        delvar_masked.run(verbose=True, xlow=2 * u.pix, xhigh=50 * u.pix)
+        plt.savefig(osjoin(fig_path, 'missing_data_delvar_masked.png'))
+        plt.close()
+
+        # What happens if we just pad that image with empty values
+
+        # From:
+        # https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.pad.html
+        def pad_with(vector, pad_width, iaxis, kwargs):
+            pad_value = kwargs.get('padder', 0.)
+            vector[:pad_width[0]] = pad_value
+            vector[-pad_width[1]:] = pad_value
+            return vector
+
+        padded_masked_img = np.pad(masked_img, 128, pad_with, padder=np.NaN)
+
+        from scipy import ndimage as nd
+        labs, num = nd.label(np.isfinite(padded_masked_img), np.ones((3, 3)))
+        # Keep the largest regions
+        padded_masked_img[np.where(labs > 1)] = np.NaN
+
+        plt.imshow(padded_masked_img, origin='lower')
+        plt.colorbar()
+        plt.tight_layout()
+        plt.savefig(osjoin(fig_path, 'missing_data_image_masked_padded.png'))
+        plt.close()
+
+        pspec_masked_pad = PowerSpectrum(fits.PrimaryHDU(padded_masked_img))
+        pspec_masked_pad.run(verbose=True, high_cut=10**-1.25 / u.pix)
+        plt.savefig(osjoin(fig_path, 'missing_data_pspec_masked_pad.png'))
+        plt.close()
+
+        delvar_masked_padded = DeltaVariance(fits.PrimaryHDU(padded_masked_img))
+        delvar_masked_padded.run(verbose=True, xlow=2 * u.pix, xhigh=70 * u.pix)
+        plt.savefig(osjoin(fig_path, 'missing_data_delvar_masked_pad.png'))
+        plt.close()
+
+        noise_rms = 1.
+        noisy_img = img + np.random.normal(0., noise_rms, img.shape)
+
+        plt.imshow(noisy_img, origin='lower')
+        plt.colorbar()
+        plt.tight_layout()
+        plt.savefig(osjoin(fig_path, 'missing_data_image_noisy.png'))
+        plt.close()
+
+        pspec_noisy = PowerSpectrum(fits.PrimaryHDU(noisy_img))
+        pspec_noisy.run(verbose=True, high_cut=10**-1.2 / u.pix)
+        plt.savefig(osjoin(fig_path, 'missing_data_pspec_noisy.png'))
+        plt.close()
+
+        delvar_noisy = DeltaVariance(fits.PrimaryHDU(noisy_img))
+        delvar_noisy.run(verbose=True, xlow=10 * u.pix, xhigh=70 * u.pix)
+        plt.savefig(osjoin(fig_path, 'missing_data_delvar_noisy.png'))
+        plt.close()
+
+        # noisy_masked_img = noisy_img.copy()
+        # noisy_masked_img[noisy_masked_img < 5 * noise_rms] = np.NaN
+
+        # pspec_noisy_masked = PowerSpectrum(fits.PrimaryHDU(noisy_masked_img))
+        # pspec_noisy_masked.run(verbose=True, high_cut=10**-1.2 / u.pix)
+        # plt.savefig(osjoin(fig_path, 'missing_data_pspec_noisy.png'))
+        # plt.close()
+
+        # delvar_noisy_masked = DeltaVariance(fits.PrimaryHDU(noisy_masked_img))
+        # delvar_noisy_masked.run(verbose=True, xlow=10 * u.pix, xhigh=70 * u.pix)
+
+    if run_data_for_tutorials:
+
+        # Make moment 0 maps for the tutorial data
+
+        fid_mom0 = fits.open("../../testingdata/Fiducial0_flatrho_0021_00_radmc_moment0.fits")[0]
+        des_mom0 = fits.open("../../testingdata/Design4_flatrho_0021_00_radmc_moment0.fits")[0]
+
+        from mpl_toolkits.axes_grid import make_axes_locatable
+
+        ax = plt.subplot(121)
+        im1 = plt.imshow(fid_mom0.data / 1000., origin='lower')
+        ax.set_title("Fiducial")
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes("right", "5%", pad="3%")
+        cb = plt.colorbar(im1, cax=cax)
+
+        ax2 = plt.subplot(122)
+        im2 = plt.imshow(des_mom0.data / 1000., origin='lower')
+        ax2.set_title("Design")
+        divider = make_axes_locatable(ax2)
+        cax2 = divider.append_axes("right", "5%", pad="3%")
+        cb2 = plt.colorbar(im2, cax=cax2)
+        cb2.set_label(r"K km s$^{-1}$")
+
+        plt.tight_layout()
+
+        plt.savefig(osjoin(fig_path, "design_fiducial_moment0.png"))
+        plt.close()

--- a/docs/tutorials/metrics/code_for_metric_tutorials.py
+++ b/docs/tutorials/metrics/code_for_metric_tutorials.py
@@ -4,326 +4,330 @@ Contains the code used in the tutorials. Saves the example images to the
 images/ folder.
 '''
 
-import os
-from os.path import join as osjoin
-import matplotlib.pyplot as plt
-import seaborn as sb
-import astropy.units as u
-from astropy.io import fits
-import numpy as np
-from spectral_cube import SpectralCube
+RUN_CODE = False
 
-# Use my default seaborn setting
-sb.set(font='Times New Roman', style='ticks')
-sb.set_context("poster", font_scale=1.0)
+if RUN_CODE:
 
-data_path = "../../../testingdata"
+    import os
+    from os.path import join as osjoin
+    import matplotlib.pyplot as plt
+    import seaborn as sb
+    import astropy.units as u
+    from astropy.io import fits
+    import numpy as np
+    from spectral_cube import SpectralCube
 
-fig_path = 'images'
+    # Use my default seaborn setting
+    sb.set(font='Times New Roman', style='ticks')
+    sb.set_context("poster", font_scale=1.0)
 
-# Choose which methods to run
-run_bispec = False
-run_cramer = False
-run_delvar = False
-run_dendro = False
-run_genus = False
-run_mvc = False
-run_pca = False
-run_pdf = False
-run_pspec = False
-run_scf = False
-run_moments = False
-# run_tsallis = False
-run_vca = False
-run_vcs = False
-run_wavelet = False
+    data_path = "../../../testingdata"
 
-# Bispectrum
-if run_bispec:
-    from turbustat.statistics import Bispectrum_Distance
+    fig_path = 'images'
 
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
+    # Choose which methods to run
+    run_bispec = False
+    run_cramer = False
+    run_delvar = False
+    run_dendro = False
+    run_genus = False
+    run_mvc = False
+    run_pca = False
+    run_pdf = False
+    run_pspec = False
+    run_scf = False
+    run_moments = False
+    # run_tsallis = False
+    run_vca = False
+    run_vcs = False
+    run_wavelet = False
 
-    bispec = Bispectrum_Distance(moment0_fid, moment0,
-                                 stat_kwargs={'nsamples': 10000})
-    bispec.distance_metric(verbose=True,
-                           save_name=osjoin(fig_path, "bispectrum_distmet.png"))
+    # Bispectrum
+    if run_bispec:
+        from turbustat.statistics import Bispectrum_Distance
 
-    print(bispec.surface_distance)
-    print(bispec.mean_distance)
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
 
-# Cramer Statistic
-if run_cramer:
+        bispec = Bispectrum_Distance(moment0_fid, moment0,
+                                     stat_kwargs={'nsamples': 10000})
+        bispec.distance_metric(verbose=True,
+                               save_name=osjoin(fig_path, "bispectrum_distmet.png"))
 
-    from turbustat.statistics import Cramer_Distance
+        print(bispec.surface_distance)
+        print(bispec.mean_distance)
 
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-    cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
+    # Cramer Statistic
+    if run_cramer:
 
-    cramer = Cramer_Distance(cube_fid, cube, noise_value1=-np.inf,
-                             noise_value2=-np.inf)
-    cramer.distance_metric(normalize=True, n_jobs=1, verbose=True,
-                           save_name=osjoin(fig_path, "cramer_distmet.png"))
+        from turbustat.statistics import Cramer_Distance
 
-    print(cramer.distance)
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+        cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
 
-# Delta-Variance
-if run_delvar:
-    from turbustat.statistics import DeltaVariance_Distance
+        cramer = Cramer_Distance(cube_fid, cube, noise_value1=-np.inf,
+                                 noise_value2=-np.inf)
+        cramer.distance_metric(normalize=True, n_jobs=1, verbose=True,
+                               save_name=osjoin(fig_path, "cramer_distmet.png"))
 
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    moment0_err = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[1]
+        print(cramer.distance)
 
-    moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
-    moment0_fid_err = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[1]
+    # Delta-Variance
+    if run_delvar:
+        from turbustat.statistics import DeltaVariance_Distance
 
-    delvar = DeltaVariance_Distance(moment0_fid, moment0, weights1=moment0_err,
-                                    weights2=moment0_fid_err)
-    delvar.distance_metric(verbose=True, xunit=u.pix,
-                           save_name=osjoin(fig_path, "delvar_distmet.png"))
-    print(delvar.curve_distance)
-    print(delvar.slope_distance)
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        moment0_err = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[1]
 
-    # Now with fitting limits
-    delvar_fit = DeltaVariance_Distance(moment0_fid, moment0, weights1=moment0_err,
-                                        weights2=moment0_fid_err,
-                                        delvar_kwargs={'xlow': 4 * u.pix,
-                                                       'xhigh': 10 * u.pix})
-    delvar_fit.distance_metric(verbose=True, xunit=u.pix,
-                               save_name=osjoin(fig_path, "delvar_distmet_fitlimits.png"))
+        moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
+        moment0_fid_err = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[1]
 
-    print(delvar_fit.curve_distance)
-    print(delvar_fit.slope_distance)
+        delvar = DeltaVariance_Distance(moment0_fid, moment0, weights1=moment0_err,
+                                        weights2=moment0_fid_err)
+        delvar.distance_metric(verbose=True, xunit=u.pix,
+                               save_name=osjoin(fig_path, "delvar_distmet.png"))
+        print(delvar.curve_distance)
+        print(delvar.slope_distance)
 
-    delvar_fitdiff = DeltaVariance_Distance(moment0_fid, moment0, weights1=moment0_err,
+        # Now with fitting limits
+        delvar_fit = DeltaVariance_Distance(moment0_fid, moment0, weights1=moment0_err,
                                             weights2=moment0_fid_err,
                                             delvar_kwargs={'xlow': 4 * u.pix,
-                                                           'xhigh': 10 * u.pix},
-                                            delvar2_kwargs={'xlow': 6 * u.pix,
-                                                            'xhigh': 20 * u.pix})
-    delvar_fitdiff.distance_metric(verbose=True, xunit=u.pix,
-                                   save_name=osjoin(fig_path, "delvar_distmet_fitlimits_diff.png"))
+                                                           'xhigh': 10 * u.pix})
+        delvar_fit.distance_metric(verbose=True, xunit=u.pix,
+                                   save_name=osjoin(fig_path, "delvar_distmet_fitlimits.png"))
 
-    print(delvar_fitdiff.curve_distance)
-    print(delvar_fitdiff.slope_distance)
+        print(delvar_fit.curve_distance)
+        print(delvar_fit.slope_distance)
 
+        delvar_fitdiff = DeltaVariance_Distance(moment0_fid, moment0, weights1=moment0_err,
+                                                weights2=moment0_fid_err,
+                                                delvar_kwargs={'xlow': 4 * u.pix,
+                                                               'xhigh': 10 * u.pix},
+                                                delvar2_kwargs={'xlow': 6 * u.pix,
+                                                                'xhigh': 20 * u.pix})
+        delvar_fitdiff.distance_metric(verbose=True, xunit=u.pix,
+                                       save_name=osjoin(fig_path, "delvar_distmet_fitlimits_diff.png"))
 
-# Dendrograms
-if run_dendro:
+        print(delvar_fitdiff.curve_distance)
+        print(delvar_fitdiff.slope_distance)
 
-    from turbustat.statistics import Dendrogram_Distance
 
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-    cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
+    # Dendrograms
+    if run_dendro:
 
-    dend_dist = Dendrogram_Distance(cube_fid, cube,
-                                    min_deltas=np.logspace(-2, 0, 50),
-                                    dendro_params={"min_value": 0.005,
-                                                   "min_npix": 50})
+        from turbustat.statistics import Dendrogram_Distance
 
-    dend_dist.distance_metric(verbose=True,
-                  save_name=osjoin(fig_path, "dendrogram_distmet.png"))
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+        cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
 
-    print(dend_dist.histogram_distance)
-    print(dend_dist.num_distance)
+        dend_dist = Dendrogram_Distance(cube_fid, cube,
+                                        min_deltas=np.logspace(-2, 0, 50),
+                                        dendro_params={"min_value": 0.005,
+                                                       "min_npix": 50})
 
-if run_genus:
+        dend_dist.distance_metric(verbose=True,
+                      save_name=osjoin(fig_path, "dendrogram_distmet.png"))
 
-    from turbustat.statistics import Genus_Distance
+        print(dend_dist.histogram_distance)
+        print(dend_dist.num_distance)
 
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
+    if run_genus:
 
-    genus = Genus_Distance(moment0_fid, moment0,
-                           lowdens_percent=15, highdens_percent=85, numpts=100,
-                           genus_kwargs=dict(min_size=4 * u.pix**2),
-                           smoothing_radii=np.linspace(1, moment0.shape[0] / 10., 5))
-    genus.distance_metric(verbose=True, save_name=osjoin(fig_path, "genus_distmet.png"))
+        from turbustat.statistics import Genus_Distance
 
-# MVC
-if run_mvc:
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
 
-    from turbustat.statistics import MVC_Distance
+        genus = Genus_Distance(moment0_fid, moment0,
+                               lowdens_percent=15, highdens_percent=85, numpts=100,
+                               genus_kwargs=dict(min_size=4 * u.pix**2),
+                               smoothing_radii=np.linspace(1, moment0.shape[0] / 10., 5))
+        genus.distance_metric(verbose=True, save_name=osjoin(fig_path, "genus_distmet.png"))
 
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    centroid = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_centroid.fits"))[0]
-    lwidth = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_linewidth.fits"))[0]
+    # MVC
+    if run_mvc:
 
-    data = {"moment0": [moment0.data, moment0.header],
-            "centroid": [centroid.data, centroid.header],
-            "linewidth": [lwidth.data, lwidth.header]}
+        from turbustat.statistics import MVC_Distance
 
-    moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
-    centroid_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_centroid.fits"))[0]
-    lwidth_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_linewidth.fits"))[0]
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        centroid = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_centroid.fits"))[0]
+        lwidth = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_linewidth.fits"))[0]
 
-    data_fid = {"moment0": [moment0_fid.data, moment0_fid.header],
-                "centroid": [centroid_fid.data, centroid_fid.header],
-                "linewidth": [lwidth_fid.data, lwidth_fid.header]}
+        data = {"moment0": [moment0.data, moment0.header],
+                "centroid": [centroid.data, centroid.header],
+                "linewidth": [lwidth.data, lwidth.header]}
 
-    mvc = MVC_Distance(data_fid, data)
-    mvc.distance_metric(verbose=True, xunit=u.pix**-1,
-                        save_name=osjoin(fig_path, 'mvc_distmet.png'))
-    print(mvc.distance)
+        moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
+        centroid_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_centroid.fits"))[0]
+        lwidth_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_linewidth.fits"))[0]
 
-    # With bounds
-    mvc = MVC_Distance(data_fid, data, low_cut=0.02 / u.pix,
-                       high_cut=0.1 / u.pix)
-    mvc.distance_metric(verbose=True, xunit=u.pix**-1,
-                        save_name=osjoin(fig_path, 'mvc_distmet_lims.png'))
-    print(mvc.distance)
+        data_fid = {"moment0": [moment0_fid.data, moment0_fid.header],
+                    "centroid": [centroid_fid.data, centroid_fid.header],
+                    "linewidth": [lwidth_fid.data, lwidth_fid.header]}
 
-# PCA
-if run_pca:
+        mvc = MVC_Distance(data_fid, data)
+        mvc.distance_metric(verbose=True, xunit=u.pix**-1,
+                            save_name=osjoin(fig_path, 'mvc_distmet.png'))
+        print(mvc.distance)
 
-    from turbustat.statistics import PCA_Distance
+        # With bounds
+        mvc = MVC_Distance(data_fid, data, low_cut=0.02 / u.pix,
+                           high_cut=0.1 / u.pix)
+        mvc.distance_metric(verbose=True, xunit=u.pix**-1,
+                            save_name=osjoin(fig_path, 'mvc_distmet_lims.png'))
+        print(mvc.distance)
 
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-    cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
+    # PCA
+    if run_pca:
 
-    pca = PCA_Distance(cube_fid, cube, n_eigs=50, mean_sub=True)
-    pca.distance_metric(verbose=True,
-                        save_name=osjoin(fig_path, 'pca_distmet.png'))
+        from turbustat.statistics import PCA_Distance
 
-    print(pca.distance)
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+        cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
 
-# PDF
-if run_pdf:
+        pca = PCA_Distance(cube_fid, cube, n_eigs=50, mean_sub=True)
+        pca.distance_metric(verbose=True,
+                            save_name=osjoin(fig_path, 'pca_distmet.png'))
 
-    from turbustat.statistics import PDF_Distance
+        print(pca.distance)
 
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
+    # PDF
+    if run_pdf:
 
-    pdf = PDF_Distance(moment0_fid, moment0, min_val1=0.0, min_val2=0.0,
-                       do_fit=True, normalization_type=None)
-    pdf.distance_metric(verbose=True,
-                        save_name=osjoin(fig_path, "pdf_distmet.png"))
+        from turbustat.statistics import PDF_Distance
 
-    print(pdf.hellinger_distance)
-    print(pdf.ks_distance)
-    print(pdf.lognormal_distance)
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
 
+        pdf = PDF_Distance(moment0_fid, moment0, min_val1=0.0, min_val2=0.0,
+                           do_fit=True, normalization_type=None)
+        pdf.distance_metric(verbose=True,
+                            save_name=osjoin(fig_path, "pdf_distmet.png"))
 
-# PSpec
-if run_pspec:
+        print(pdf.hellinger_distance)
+        print(pdf.ks_distance)
+        print(pdf.lognormal_distance)
 
-    from turbustat.statistics import PSpec_Distance
 
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
+    # PSpec
+    if run_pspec:
 
-    pspec = PSpec_Distance(moment0_fid, moment0,
-                           low_cut=0.025 / u.pix, high_cut=0.1 / u.pix,)
-    pspec.distance_metric(verbose=True, xunit=u.pix**-1,
-                          save_name=osjoin(fig_path, "pspec_distmet.png"))
+        from turbustat.statistics import PSpec_Distance
 
-    print(pspec.distance)
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
 
+        pspec = PSpec_Distance(moment0_fid, moment0,
+                               low_cut=0.025 / u.pix, high_cut=0.1 / u.pix,)
+        pspec.distance_metric(verbose=True, xunit=u.pix**-1,
+                              save_name=osjoin(fig_path, "pspec_distmet.png"))
 
-# SCF
-if run_scf:
+        print(pspec.distance)
 
-    from turbustat.statistics import SCF_Distance
 
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-    cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
+    # SCF
+    if run_scf:
 
-    scf = SCF_Distance(cube_fid, cube, size=11)
-    scf.distance_metric(verbose=True,
-                        save_name=osjoin(fig_path, "scf_distmet.png"))
+        from turbustat.statistics import SCF_Distance
 
-    print(scf.distance)
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+        cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
 
-# Moments
-if run_moments:
+        scf = SCF_Distance(cube_fid, cube, size=11)
+        scf.distance_metric(verbose=True,
+                            save_name=osjoin(fig_path, "scf_distmet.png"))
 
-    from turbustat.statistics import StatMoments_Distance
+        print(scf.distance)
 
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
+    # Moments
+    if run_moments:
 
-    moments = StatMoments_Distance(moment0_fid, moment0, radius=5 * u.pix,
-                                   periodic1=True, periodic2=True)
-    moments.distance_metric(verbose=True,
-                            save_name=osjoin(fig_path, "statmoments_distmet.png"))
+        from turbustat.statistics import StatMoments_Distance
 
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
 
-# Tsallis
-# if run_tsallis:
-#     from turbustat.statistics import Tsallis
+        moments = StatMoments_Distance(moment0_fid, moment0, radius=5 * u.pix,
+                                       periodic1=True, periodic2=True)
+        moments.distance_metric(verbose=True,
+                                save_name=osjoin(fig_path, "statmoments_distmet.png"))
 
-#     moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
 
-#     tsallis = Tsallis(moment0).run(verbose=True,
-#                                    save_name=osjoin(fig_path, 'design4_tsallis.png'))
+    # Tsallis
+    # if run_tsallis:
+    #     from turbustat.statistics import Tsallis
 
-#     # Tsallis parameters plot.
-#     tsallis.plot_parameters(save_name=osjoin(fig_path, 'design4_tsallis_params.png'))
+    #     moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
 
-#     # With physical lags units
-#     phys_lags = np.arange(0.025, 0.5, 0.05) * u.pc
-#     tsallis = Tsallis(moment0, lags=phys_lags, distance=250 * u.pc)
-#     tsallis.run(verbose=True,
-#                 save_name=osjoin(fig_path, 'design4_tsallis_physlags.png'))
+    #     tsallis = Tsallis(moment0).run(verbose=True,
+    #                                    save_name=osjoin(fig_path, 'design4_tsallis.png'))
 
-#     # Not periodic
-#     tsallis_noper = Tsallis(moment0).run(verbose=True, periodic=False,
-#                                          save_name=osjoin(fig_path, 'design4_tsallis_noper.png'))
+    #     # Tsallis parameters plot.
+    #     tsallis.plot_parameters(save_name=osjoin(fig_path, 'design4_tsallis_params.png'))
 
-#     # Change sigma clip
-#     tsallis = Tsallis(moment0).run(verbose=True, sigma_clip=3,
-#                                    save_name=osjoin(fig_path, 'design4_tsallis_sigclip.png'))
+    #     # With physical lags units
+    #     phys_lags = np.arange(0.025, 0.5, 0.05) * u.pc
+    #     tsallis = Tsallis(moment0, lags=phys_lags, distance=250 * u.pc)
+    #     tsallis.run(verbose=True,
+    #                 save_name=osjoin(fig_path, 'design4_tsallis_physlags.png'))
 
-#     tsallis.plot_parameters(save_name=osjoin(fig_path, 'design4_tsallis_params_sigclip.png'))
+    #     # Not periodic
+    #     tsallis_noper = Tsallis(moment0).run(verbose=True, periodic=False,
+    #                                          save_name=osjoin(fig_path, 'design4_tsallis_noper.png'))
 
-# VCA
-if run_vca:
+    #     # Change sigma clip
+    #     tsallis = Tsallis(moment0).run(verbose=True, sigma_clip=3,
+    #                                    save_name=osjoin(fig_path, 'design4_tsallis_sigclip.png'))
 
-    from turbustat.statistics import VCA_Distance
+    #     tsallis.plot_parameters(save_name=osjoin(fig_path, 'design4_tsallis_params_sigclip.png'))
 
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-    cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
+    # VCA
+    if run_vca:
 
-    vca = VCA_Distance(cube_fid, cube, low_cut=0.025 / u.pix,
-                       high_cut=0.1 / u.pix)
-    vca.distance_metric(verbose=True,
-                        save_name=osjoin(fig_path, "vca_distmet.png"))
+        from turbustat.statistics import VCA_Distance
 
-    print(vca.distance)
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+        cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
 
-    vca = VCA_Distance(cube_fid, cube, low_cut=0.025 / u.pix,
-                       high_cut=0.1 / u.pix, channel_width=400 * u.m / u.s)
-    vca.distance_metric(verbose=True,
-                        save_name=osjoin(fig_path, "vca_distmet_thickchan.png"))
-    print(vca.distance)
+        vca = VCA_Distance(cube_fid, cube, low_cut=0.025 / u.pix,
+                           high_cut=0.1 / u.pix)
+        vca.distance_metric(verbose=True,
+                            save_name=osjoin(fig_path, "vca_distmet.png"))
 
+        print(vca.distance)
 
-# VCS
-if run_vcs:
+        vca = VCA_Distance(cube_fid, cube, low_cut=0.025 / u.pix,
+                           high_cut=0.1 / u.pix, channel_width=400 * u.m / u.s)
+        vca.distance_metric(verbose=True,
+                            save_name=osjoin(fig_path, "vca_distmet_thickchan.png"))
+        print(vca.distance)
 
-    from turbustat.statistics import VCS_Distance
 
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-    cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
+    # VCS
+    if run_vcs:
 
-    vcs = VCS_Distance(cube_fid, cube, fit_kwargs=dict(high_cut=0.17 / u.pix))
-    vcs.distance_metric(verbose=True,
-                        save_name=osjoin(fig_path, "vcs_distmet.png"))
+        from turbustat.statistics import VCS_Distance
 
-    print(vcs.large_scale_distance, vcs.small_scale_distance, vcs.distance, vcs.break_distance)
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+        cube_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc.fits"))[0]
 
-# Wavelets
-if run_wavelet:
-    from turbustat.statistics import Wavelet_Distance
+        vcs = VCS_Distance(cube_fid, cube, fit_kwargs=dict(high_cut=0.17 / u.pix))
+        vcs.distance_metric(verbose=True,
+                            save_name=osjoin(fig_path, "vcs_distmet.png"))
 
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
+        print(vcs.large_scale_distance, vcs.small_scale_distance, vcs.distance, vcs.break_distance)
 
-    wavelet = Wavelet_Distance(moment0_fid, moment0, xlow=2 * u.pix,
-                               xhigh=10 * u.pix)
-    wavelet.distance_metric(verbose=True,
-                            save_name=osjoin(fig_path, 'wavelet_distmet.png'))
+    # Wavelets
+    if run_wavelet:
+        from turbustat.statistics import Wavelet_Distance
 
-    print(wavelet.distance)
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        moment0_fid = fits.open(osjoin(data_path, "Fiducial0_flatrho_0021_00_radmc_moment0.fits"))[0]
+
+        wavelet = Wavelet_Distance(moment0_fid, moment0, xlow=2 * u.pix,
+                                   xhigh=10 * u.pix)
+        wavelet.distance_metric(verbose=True,
+                                save_name=osjoin(fig_path, 'wavelet_distmet.png'))
+
+        print(wavelet.distance)

--- a/docs/tutorials/metrics/code_for_metric_tutorials.py
+++ b/docs/tutorials/metrics/code_for_metric_tutorials.py
@@ -11,7 +11,7 @@ if RUN_CODE:
     import os
     from os.path import join as osjoin
     import matplotlib.pyplot as plt
-    import seaborn as sb
+    # import seaborn as sb
     import astropy.units as u
     from astropy.io import fits
     import numpy as np

--- a/docs/tutorials/statistics/code_for_tutorials.py
+++ b/docs/tutorials/statistics/code_for_tutorials.py
@@ -4,562 +4,566 @@ Contains the code used in the tutorials. Saves the example images to the
 images/ folder.
 '''
 
-import os
-from os.path import join as osjoin
-import matplotlib.pyplot as plt
-import seaborn as sb
-import astropy.units as u
-from astropy.io import fits
-import numpy as np
-from spectral_cube import SpectralCube
-
-# Use my default seaborn setting
-sb.set(font='Sans-Serif', style='ticks')
-sb.set_context("paper", font_scale=1.)
-
-data_path = "../../../testingdata"
-
-fig_path = 'images'
-
-# Choose which methods to run
-run_bispec = False
-run_delvar = False
-run_dendro = False
-run_genus = False
-run_mvc = False
-run_pca = False
-run_pdf = False
-run_pspec = False
-run_scf = False
-run_moments = False
-run_tsallis = False
-run_vca = False
-run_vcs = False
-run_wavelet = False
-
-# Bispectrum
-if run_bispec:
-    from turbustat.statistics import BiSpectrum
-
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-
-    bispec = BiSpectrum(moment0)
-    bispec.run(verbose=True, nsamples=10000,
-               save_name=osjoin(fig_path, "bispectrum_design4.png"))
-
-    # With mean subtraction
-    bispec2 = BiSpectrum(moment0)
-    bispec2.run(nsamples=10000, mean_subtract=True, seed=4242424)
-
-    # Plot comparison w/ and w/o mean sub
-
-    plt.subplot(121)
-    plt.imshow(bispec.bicoherence, vmin=0, vmax=1, origin='lower')
-    plt.title("Without mean subtraction")
-    plt.subplot(122)
-    plt.imshow(bispec2.bicoherence, vmin=0, vmax=1, origin='lower')
-    plt.title("With mean subtraction")
-    plt.savefig(osjoin(fig_path, "bispectrum_w_and_wo_meansub_coherence.png"))
-    plt.close()
-
-    # Radial and azimuthal slices
-    rad_slices = bispec.radial_slice([30, 45, 60] * u.deg, 20 * u.deg, value='bispectrum_logamp')
-    plt.errorbar(rad_slices[30][0], rad_slices[30][1], yerr=rad_slices[30][2], label='30')
-    plt.errorbar(rad_slices[45][0], rad_slices[45][1], yerr=rad_slices[45][2], label='45')
-    plt.errorbar(rad_slices[60][0], rad_slices[60][1], yerr=rad_slices[60][2], label='60')
-    plt.legend()
-    plt.xlabel("Radius")
-    plt.ylabel("log Bispectrum")
-    plt.grid()
-    plt.tight_layout()
-    plt.savefig(osjoin(fig_path, "bispectrum_radial_slices.png"))
-    plt.close()
-
-    azim_slices = bispec.azimuthal_slice([8, 16, 50], 10, value='bispectrum_logamp', bin_width=5 * u.deg)
-    plt.errorbar(azim_slices[8][0], azim_slices[8][1], yerr=azim_slices[8][2], label='8')
-    plt.errorbar(azim_slices[16][0], azim_slices[16][1], yerr=azim_slices[16][2], label='16')
-    plt.errorbar(azim_slices[50][0], azim_slices[50][1], yerr=azim_slices[50][2], label='50')
-    plt.legend()
-    plt.xlabel("Theta (rad)")
-    plt.ylabel("log Bispectrum")
-    plt.grid()
-    plt.tight_layout()
-    plt.savefig(osjoin(fig_path, "bispectrum_azim_slices.png"))
-    plt.close()
-
-
-# Delta-Variance
-if run_delvar:
-    from turbustat.statistics import DeltaVariance
-
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    moment0_err = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[1]
-
-    delvar = DeltaVariance(moment0, weights=moment0_err, distance=250 * u.pc)
-    delvar.run(verbose=True, xunit=u.pix,
-               save_name=osjoin(fig_path, "delvar_design4.png"))
-
-    # Now with fitting limits
-    delvar.run(verbose=True, xunit=u.pix, xlow=4 * u.pix, xhigh=30 * u.pix,
-               save_name=osjoin(fig_path, "delvar_design4_wlimits.png"))
-
-    # Now with fitting limits
-    delvar.run(verbose=True, xunit=u.pc, xlow=4 * u.pix, xhigh=30 * u.pix,
-               save_name=osjoin(fig_path, "delvar_design4_physunits.png"))
-
-    delvar.run(verbose=True, xunit=u.pc, xlow=4 * u.pix, xhigh=40 * u.pix,
-               brk=8 * u.pix,
-               save_name=osjoin(fig_path, "delvar_design4_break.png"))
-
-    # Look at difference w/ non-periodic boundary handling
-    # This needs to be revisited with the astropy convolution updates
-    # delvar.run(verbose=True, xunit=u.pix, xlow=4 * u.pix, xhigh=30 * u.pix,
-    #            boundary='fill',
-    #            save_name=osjoin(fig_path, "delvar_design4_boundaryfill.png"))
-
-# Dendrograms
-if run_dendro:
-
-    from turbustat.statistics import Dendrogram_Stats
-    from astrodendro import Dendrogram
-
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-    d = Dendrogram.compute(cube.data, min_value=0.005, min_delta=0.1, min_npix=50,
-                           verbose=True)
-    ax = plt.subplot(111)
-    d.plotter().plot_tree(ax)
-    plt.ylabel("Intensity (K)")
-    plt.savefig(osjoin(fig_path, "design4_dendrogram.png"))
-    plt.close()
-
-    dend_stat = Dendrogram_Stats(cube, min_deltas=np.logspace(-2, 0, 50),
-                                 dendro_params={"min_value": 0.005,
-                                                "min_npix": 50})
-
-    dend_stat.run(verbose=True,
-                  save_name=osjoin(fig_path, "design4_dendrogram_stats.png"))
-
-    # Periodic boundaries
-    dend_stat.run(verbose=True, periodic_bounds=True,
-                  save_name=osjoin(fig_path, "design4_dendrogram_stats_periodic.png"))
-
-if run_genus:
-
-    from turbustat.statistics import Genus
-
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-
-    genus = Genus(moment0, lowdens_percent=15, highdens_percent=85, numpts=100,
-                  smoothing_radii=np.linspace(1, moment0.shape[0] / 10., 5))
-    genus.run(verbose=True, min_size=4, save_name=osjoin(fig_path, "genus_design4.png"))
-
-    # With min/max values.
-    genus = Genus(moment0, min_value=137, max_value=353, numpts=100,
-                  smoothing_radii=np.linspace(1, moment0.shape[0] / 10., 5))
-    genus.run(verbose=True, min_size=4, save_name=osjoin(fig_path, "genus_design4_minmaxval.png"))
-
-    # Requiring regions be larger than the beam
-    moment0.header["BMAJ"] = 2e-5  # deg.
-    genus = Genus(moment0, lowdens_percent=15, highdens_percent=85,
-                  smoothing_radii=[1] * u.pix)
-    genus.run(verbose=True, use_beam=True, save_name=osjoin(fig_path, "genus_design4_beamarea.png"))
-
-    # With a distance
-    genus = Genus(moment0, lowdens_percent=15, highdens_percent=85,
-                  smoothing_radii=u.Quantity([0.04 * u.pc]),
-                  distance=250 * u.pc)
-    genus.run(verbose=True, min_size=40 * u.AU**2,
-              save_name=osjoin(fig_path, "genus_design4_physunits.png"))
-
-# MVC
-if run_mvc:
-
-    from turbustat.statistics import MVC
-
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    centroid = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_centroid.fits"))[0]
-    lwidth = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_linewidth.fits"))[0]
-
-    mvc = MVC(centroid, moment0, lwidth)
-    mvc.run(verbose=True, xunit=u.pix**-1,
-            save_name=osjoin(fig_path, 'mvc_design4.png'))
-
-    # With bounds
-    mvc.run(verbose=True, xunit=u.pix**-1, low_cut=0.02 / u.pix,
-            high_cut=0.1 / u.pix,
-            save_name=osjoin(fig_path, 'mvc_design4_limitedfreq.png'))
-
-    # With a break
-    mvc = MVC(centroid, moment0, lwidth, distance=250 * u.pc)
-    mvc.run(verbose=True, xunit=u.pix**-1, low_cut=0.02 / u.pix,
-            high_cut=0.4 / u.pix,
-            fit_kwargs=dict(brk=0.1 / u.pix), fit_2D=False,
-            save_name=osjoin(fig_path, "mvc_design4_breakfit.png"))
-
-    # With phys units
-    mvc = MVC(centroid, moment0, lwidth, distance=250 * u.pc)
-    mvc.run(verbose=True, xunit=u.pc**-1, low_cut=0.02 / u.pix,
-            high_cut=0.1 / u.pix, fit_2D=False,
-            save_name=osjoin(fig_path, 'mvc_design4_physunits.png'))
-
-    # Azimuthal limits
-    mvc = MVC(centroid, moment0, lwidth, distance=250 * u.pc)
-    mvc.run(verbose=True, xunit=u.pc**-1, low_cut=0.02 / u.pix,
-            high_cut=0.1 / u.pix, fit_2D=False,
-            radial_pspec_kwargs={"theta_0": 1.13 * u.rad, "delta_theta": 40 * u.deg},
-            save_name=osjoin(fig_path, 'mvc_design4_physunits_azimlimits.png'))
-
-# PCA
-if run_pca:
-
-    from turbustat.statistics import PCA
-
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-
-    pca = PCA(cube, distance=250. * u.pc)
-    pca.run(verbose=True, mean_sub=False,
-            min_eigval=1e-4, spatial_output_unit=u.pc,
-            spectral_output_unit=u.m / u.s,
-            beam_fwhm=10 * u.arcsec, brunt_beamcorrect=False,
-            save_name=osjoin(fig_path, "pca_design4_default.png"))
-
-    # With beam correction
-    pca.run(verbose=True, mean_sub=False,
-            min_eigval=1e-4, spatial_output_unit=u.pc,
-            spectral_output_unit=u.m / u.s,
-            beam_fwhm=10 * u.arcsec, brunt_beamcorrect=True,
-            save_name=osjoin(fig_path, "pca_design4_beamcorr.png"))
-
-    # With mean_sub
-    pca_ms = PCA(cube, distance=250. * u.pc)
-    pca_ms.run(verbose=True, mean_sub=True,
-               min_eigval=1e-4, spatial_output_unit=u.pc,
-               spectral_output_unit=u.m / u.s,
-               beam_fwhm=10 * u.arcsec, brunt_beamcorrect=True,
-               save_name=osjoin(fig_path, "pca_design4_meansub.png"))
-
-    # Individual steps
-
-    pca.compute_pca(mean_sub=False, n_eigs='auto', min_eigval=1.e-4, eigen_cut_method='value')
-    print(pca.n_eigs)
-
-    pca.compute_pca(mean_sub=False, n_eigs='auto', min_eigval=0.99, eigen_cut_method='proportion')
-    print(pca.n_eigs)
-
-    pca.compute_pca(mean_sub=False, n_eigs='auto', min_eigval=1.e-4, eigen_cut_method='value')
-    pca.find_spatial_widths(method='contour', beam_fwhm=10 * u.arcsec,
-                            brunt_beamcorrect=True, diagnosticplots=True)
-    plt.savefig(osjoin(fig_path, "pca_autocorrimgs_contourfit_Design4.png"))
-    plt.close()
-
-    pca.find_spectral_widths(method='walk-down')
-    autocorr_spec = pca.autocorr_spec()
-    x = np.fft.rfftfreq(500) * 500
-    fig, axes = plt.subplots(3, 3, sharex=True, sharey=True, figsize=(10, 8))
-    for i, ax in zip(range(9), axes.ravel()):
-        ax.plot(x, autocorr_spec[:251, i])
-        ax.axhline(np.exp(-1), label='exp(-1)', color='r', linestyle='--')
-        ax.axvline(pca.spectral_width(u.pix)[i].value,
-                   label='Fitted Width',
-                   color='g', linestyle='-.')
-        # ax.set_yticks([])
-        ax.set_title("{}".format(i + 1))
-        ax.set_xlim([0, 50])
-        if i == 0:
-            ax.legend()
-    fig.tight_layout()
-    fig.savefig(osjoin(fig_path, "pca_autocorrspec_Design4.png"))
-    plt.close()
-
-    pca.fit_plaw(fit_method='odr', verbose=True)
-    plt.savefig(osjoin(fig_path, "pca_design4_plaw_odr.png"))
-    plt.close()
-
-    pca.fit_plaw(fit_method='bayes', verbose=True)
-    plt.savefig(osjoin(fig_path, "pca_design4_plaw_mcmc.png"))
-    plt.close()
-
-    print(pca.gamma)
-
-    print(pca.sonic_length(T_k=10 * u.K, mu=1.36, unit=u.pc))
-
-# PDF
-if run_pdf:
-
-    from turbustat.statistics import PDF
-
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-    pdf_mom0 = PDF(moment0, min_val=0.0, bins=None)
-    pdf_mom0.run(verbose=True,
-                 save_name=osjoin(fig_path, "pdf_design4_mom0.png"))
-
-    print(pdf_mom0.find_percentile(500))
-    print(pdf_mom0.find_at_percentile(96.3134765625))
-
-    moment0_error = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[1]
-    pdf_mom0 = PDF(moment0, min_val=0.0, bins=None, weights=moment0_error.data**-2)
-    pdf_mom0.run(verbose=True,
-                 save_name=osjoin(fig_path, "pdf_design4_mom0_weights.png"))
-
-    pdf_mom0 = PDF(moment0, normalization_type='standardize')
-    pdf_mom0.run(verbose=True, do_fit=False,
-                 save_name=osjoin(fig_path, "pdf_design4_mom0_stand.png"))
-
-    pdf_mom0 = PDF(moment0, normalization_type='center')
-    pdf_mom0.run(verbose=True, do_fit=False,
-                 save_name=osjoin(fig_path, "pdf_design4_mom0_center.png"))
-
-    pdf_mom0 = PDF(moment0, normalization_type='normalize')
-    pdf_mom0.run(verbose=True, do_fit=False,
-                 save_name=osjoin(fig_path, "pdf_design4_mom0_norm.png"))
-
-    pdf_mom0 = PDF(moment0, normalization_type='normalize_by_mean')
-    pdf_mom0.run(verbose=True, do_fit=False,
-                 save_name=osjoin(fig_path, "pdf_design4_mom0_normmean.png"))
-
-    pdf_mom0 = PDF(moment0, min_val=0.0, bins=None)
-    pdf_mom0.run(verbose=True, fit_type='mcmc',
-                 save_name=osjoin(fig_path, "pdf_design4_mom0_mcmc.png"))
-
-    # Make a trace plot
-    pdf_mom0.trace_plot()
-    plt.savefig(osjoin(fig_path, "pdf_design4_mom0_mcmc_trace.png"))
-    plt.close()
-
-    # Make a corner plot
-    pdf_mom0.corner_plot(quantiles=[0.16, 0.5, 0.84])
-    plt.savefig(osjoin(fig_path, "pdf_design4_mom0_mcmc_corner.png"))
-    plt.close()
-
-    # Fit a power-law distribution
-    import scipy.stats as stats
-    pdf_mom0 = PDF(moment0, min_val=250.0, normalization_type=None)
-    pdf_mom0.run(verbose=True, model=stats.pareto, fit_type='mle', floc=False,
-                 save_name=osjoin(fig_path, "pdf_design4_mom0_plaw.png"))
-
-    cube = SpectralCube.read(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))
-    pdf_cube = PDF(cube)
-    pdf_cube.run(verbose=True, do_fit=False,
-                 save_name=osjoin(fig_path, "pdf_design4.png"))
-
-# PSpec
-if run_pspec:
-
-    from turbustat.statistics import PowerSpectrum
-
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-
-    pspec = PowerSpectrum(moment0, distance=250 * u.pc)
-    pspec.run(verbose=True, xunit=u.pix**-1,
-              save_name=osjoin(fig_path, "design4_pspec.png"))
-
-    pspec.run(verbose=True, xunit=u.pix**-1,
-              low_cut=0.025 / u.pix, high_cut=0.1 / u.pix,
-              save_name=osjoin(fig_path, "design4_pspec_limitedfreq.png"))
-
-    print(pspec.slope2D, pspec.slope2D_err)
-    print(pspec.ellip2D, pspec.ellip2D_err)
-    print(pspec.theta2D, pspec.theta2D_err)
-
-    # How about fitting a break?
-    pspec = PowerSpectrum(moment0, distance=250 * u.pc)
-    pspec.run(verbose=True, xunit=u.pc**-1,
-              low_cut=0.025 / u.pix, high_cut=0.4 / u.pix, fit_2D=False,
-              fit_kwargs={'brk': 0.1 / u.pix, 'log_break': False},
-              save_name=osjoin(fig_path, "design4_pspec_breakfit.png"))
-
-    pspec = PowerSpectrum(moment0, distance=250 * u.pc)
-    pspec.run(verbose=True, xunit=u.pc**-1,
-              low_cut=0.025 / u.pix, high_cut=0.4 / u.pix, fit_2D=False,
-              fit_kwargs={'brk': 0.1 / u.pix, 'log_break': False},
-              radial_pspec_kwargs={"theta_0": 1.13 * u.rad, "delta_theta": 40 * u.deg},
-              save_name=osjoin(fig_path, "design4_pspec_breakfit_azimlimits.png"))
-
-    pspec = PowerSpectrum(moment0, distance=250 * u.pc)
-    pspec.run(verbose=True, xunit=u.pix**-1,
-              low_cut=0.025 / u.pix, high_cut=0.1 / u.pix,
-              fit_kwargs={'weighted_fit': True},
-              save_name=osjoin(fig_path, "design4_pspec_limitedfreq_weightfit.png"))
-
-
-# SCF
-if run_scf:
-
-    from turbustat.statistics import SCF
-
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-
-    scf = SCF(cube, size=11)
-    scf.run(verbose=True,
-            save_name=osjoin(fig_path, "design4_scf.png"))
-
-    print(scf.slope2D, scf.slope2D_err)
-    print(scf.ellip2D, scf.ellip2D_err)
-    print(scf.theta2D, scf.theta2D_err)
-
-    # With fit limits
-    scf.run(verbose=True, xlow=1 * u.pix, xhigh=5 * u.pix,
-            save_name=osjoin(fig_path, "design4_scf_fitlimits.png"))
-
-    # With azimuthal constraints
-    scf.run(verbose=True, xlow=1 * u.pix, xhigh=5 * u.pix,
-            radialavg_kwargs={"theta_0": 1.13 * u.rad, "delta_theta": 70 * u.deg},
-            save_name=osjoin(fig_path, "design4_scf_fitlimits_azimlimits.png"))
-
-
-    # Custom lags w/ phys units
-    distance = 250 * u.pc  # Assume a distance
-    phys_conv = (np.abs(cube.header['CDELT2']) * u.deg).to(u.rad).value * distance
-    custom_lags = np.arange(-4.5, 5, 1.5) * phys_conv
-    scf_physroll = SCF(cube, roll_lags=custom_lags, distance=distance)
-    scf_physroll.run(verbose=True, xunit=u.pc,
-                     save_name=osjoin(fig_path, "design4_scf_physroll.png"))
-
-    # boundary cut
-    scf = SCF(cube, size=11)
-    scf.run(verbose=True, boundary='cut',
-            save_name=osjoin(fig_path, "design4_scf_boundcut.png"))
-
-
-# Moments
-if run_moments:
-
-    from turbustat.statistics import StatMoments
-
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-
-    moments = StatMoments(moment0, radius=5 * u.pix)
-    moments.run(verbose=True, periodic=True,
-                save_name=osjoin(fig_path, "design4_statmoments.png"))
-
-    moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists.png"))
-
-    # Demonstrate passing a weight array in
-    np.random.seed(3434789)
-    noise = moment0.data * 0.1 + np.random.normal(0, 0.1, size=moment0.data.shape)
-    moments_weighted = StatMoments(moment0, radius=5 * u.pix, weights=noise**-2)
-    moments_weighted.run(verbose=True, periodic=True,
-                         save_name=osjoin(fig_path, "design4_statmoments_randweights.png"))
-    moments_weighted.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_randweights.png"))
-
-    # Too small radius
-    moments.run(verbose=False, radius=2 * u.pix)
-    moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_rad_2pix.png"))
-
-    # Larger radius
-    moments.run(verbose=False, radius=10 * u.pix)
-    moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_rad_10pix.png"))
-
-    # Much larger radius
-    moments.run(verbose=False, radius=32 * u.pix)
-    moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_rad_32pix.png"))
-
-    # Other units
-    moments = StatMoments(moment0, radius=0.25 * u.pc, distance=250 * u.pc)
-    moments.run(verbose=False, periodic=True)
-    moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_physunits.png"))
-
-# Tsallis
-if run_tsallis:
-    from turbustat.statistics import Tsallis
-
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-
-    tsallis = Tsallis(moment0).run(verbose=True,
-                                   save_name=osjoin(fig_path, 'design4_tsallis.png'))
-
-    # Tsallis parameters plot.
-    tsallis.plot_parameters(save_name=osjoin(fig_path, 'design4_tsallis_params.png'))
-
-    # With physical lags units
-    # Get a float rounding error, so just take first 3 decimal points
-    phys_lags = np.around(np.arange(0.025, 0.5, 0.05), 3) * u.pc
-    tsallis = Tsallis(moment0, lags=phys_lags, distance=250 * u.pc)
-    tsallis.run(verbose=True,
-                save_name=osjoin(fig_path, 'design4_tsallis_physlags.png'))
-
-    # Not periodic
-    tsallis_noper = Tsallis(moment0).run(verbose=True, periodic=False,
-                                         save_name=osjoin(fig_path, 'design4_tsallis_noper.png'))
-
-    # Change sigma clip
-    tsallis = Tsallis(moment0).run(verbose=True, sigma_clip=3,
-                                   save_name=osjoin(fig_path, 'design4_tsallis_sigclip.png'))
-
-    tsallis.plot_parameters(save_name=osjoin(fig_path, 'design4_tsallis_params_sigclip.png'))
-
-# VCA
-if run_vca:
-
-    from turbustat.statistics import VCA
-
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-
-    vca = VCA(cube)
-    vca.run(verbose=True,
-            save_name=osjoin(fig_path, "design4_vca.png"))
-
-    vca.run(verbose=True, xunit=u.pix**-1, low_cut=0.02 / u.pix, high_cut=0.1 / u.pix,
-            save_name=osjoin(fig_path, "design4_vca_limitedfreq.png"))
-
-    vca = VCA(cube, distance=250 * u.pc)
-    vca.run(verbose=True, xunit=u.pc**-1, low_cut=0.02 / u.pix,
-            high_cut=0.4 / u.pix,
-            fit_kwargs=dict(brk=0.1 / u.pix), fit_2D=False,
-            save_name=osjoin(fig_path, "design4_vca_breakfit.png"))
-
-    vca_thicker = VCA(cube, distance=250 * u.pc, channel_width=400 * u.m / u.s)
-    vca_thicker.run(verbose=True, xunit=u.pc**-1, low_cut=0.02 / u.pix,
-                    high_cut=0.4 / u.pix,
-                    fit_kwargs=dict(brk=0.1 / u.pix), fit_2D=False,
-                    save_name=osjoin(fig_path, "design4_vca_400ms_channels.png"))
-
-    # W/ azimuthal constraints
-    vca = VCA(cube)
-    vca.run(verbose=True, xunit=u.pix**-1, low_cut=0.02 / u.pix, high_cut=0.1 / u.pix,
-            radial_pspec_kwargs={"theta_0": 1.13 * u.rad, "delta_theta": 40 * u.deg},
-            save_name=osjoin(fig_path, "design4_vca_limitedfreq_azimilimits.png"))
-
-
-# VCS
-if run_vcs:
-
-    from turbustat.statistics import VCS
-
-    cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
-
-    vcs = VCS(cube)
-    vcs.run(verbose=True,
-            save_name=osjoin(fig_path, "design4_vcs.png"))
-
-    vcs.run(verbose=True, high_cut=0.17 / u.pix,
-            save_name=osjoin(fig_path, "design4_vcs_lowcut.png"))
-
-    vcs.run(verbose=True, high_cut=0.17 / u.pix, xunit=(u.m / u.s)**-1,
-            save_name=osjoin(fig_path, "design4_vcs_lowcut_physunits.png"))
-
-    vcs.run(verbose=True, high_cut=0.17 / u.pix, low_cut=6e-4 / (u.m / u.s), xunit=(u.m / u.s)**-1,
-            save_name=osjoin(fig_path, "design4_vcs_bothcut_physunits.png"))
-
-# Wavelets
-if run_wavelet:
-    from turbustat.statistics import Wavelet
-
-    moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
-
-    wavelet = Wavelet(moment0).run(verbose=True,
-                                   save_name=osjoin(fig_path, 'design4_wavelet.png'))
-
-    # Limit the range
-    wavelet = Wavelet(moment0)
-    wavelet.run(verbose=True, xlow=1 * u.pix, xhigh=10 * u.pix,
-                save_name=osjoin(fig_path, 'design4_wavelet_fitlimits.png'))
-
-    phys_scales = np.arange(0.025, 0.5, 0.05) * u.pc
-    wavelet = Wavelet(moment0, distance=250 * u.pc, scales=phys_scales)
-    wavelet.run(verbose=True, xlow=1 * u.pix, xhigh=10 * u.pix, xunit=u.pc,
-                save_name=osjoin(fig_path, 'design4_wavelet_physunits.png'))
-
-    wavelet = Wavelet(moment0)
-    wavelet.run(verbose=True, scale_normalization=False, xhigh=10 * u.pix,
-                save_name=osjoin(fig_path, 'design4_wavelet_unnorm.png'))
+RUN_CODE = False
+
+if RUN_CODE:
+
+    import os
+    from os.path import join as osjoin
+    import matplotlib.pyplot as plt
+    # import seaborn as sb
+    import astropy.units as u
+    from astropy.io import fits
+    import numpy as np
+    from spectral_cube import SpectralCube
+
+    # Use my default seaborn setting
+    sb.set(font='Sans-Serif', style='ticks')
+    sb.set_context("paper", font_scale=1.)
+
+    data_path = "../../../testingdata"
+
+    fig_path = 'images'
+
+    # Choose which methods to run
+    run_bispec = False
+    run_delvar = False
+    run_dendro = False
+    run_genus = False
+    run_mvc = False
+    run_pca = False
+    run_pdf = False
+    run_pspec = False
+    run_scf = False
+    run_moments = False
+    run_tsallis = False
+    run_vca = False
+    run_vcs = False
+    run_wavelet = False
+
+    # Bispectrum
+    if run_bispec:
+        from turbustat.statistics import BiSpectrum
+
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+
+        bispec = BiSpectrum(moment0)
+        bispec.run(verbose=True, nsamples=10000,
+                   save_name=osjoin(fig_path, "bispectrum_design4.png"))
+
+        # With mean subtraction
+        bispec2 = BiSpectrum(moment0)
+        bispec2.run(nsamples=10000, mean_subtract=True, seed=4242424)
+
+        # Plot comparison w/ and w/o mean sub
+
+        plt.subplot(121)
+        plt.imshow(bispec.bicoherence, vmin=0, vmax=1, origin='lower')
+        plt.title("Without mean subtraction")
+        plt.subplot(122)
+        plt.imshow(bispec2.bicoherence, vmin=0, vmax=1, origin='lower')
+        plt.title("With mean subtraction")
+        plt.savefig(osjoin(fig_path, "bispectrum_w_and_wo_meansub_coherence.png"))
+        plt.close()
+
+        # Radial and azimuthal slices
+        rad_slices = bispec.radial_slice([30, 45, 60] * u.deg, 20 * u.deg, value='bispectrum_logamp')
+        plt.errorbar(rad_slices[30][0], rad_slices[30][1], yerr=rad_slices[30][2], label='30')
+        plt.errorbar(rad_slices[45][0], rad_slices[45][1], yerr=rad_slices[45][2], label='45')
+        plt.errorbar(rad_slices[60][0], rad_slices[60][1], yerr=rad_slices[60][2], label='60')
+        plt.legend()
+        plt.xlabel("Radius")
+        plt.ylabel("log Bispectrum")
+        plt.grid()
+        plt.tight_layout()
+        plt.savefig(osjoin(fig_path, "bispectrum_radial_slices.png"))
+        plt.close()
+
+        azim_slices = bispec.azimuthal_slice([8, 16, 50], 10, value='bispectrum_logamp', bin_width=5 * u.deg)
+        plt.errorbar(azim_slices[8][0], azim_slices[8][1], yerr=azim_slices[8][2], label='8')
+        plt.errorbar(azim_slices[16][0], azim_slices[16][1], yerr=azim_slices[16][2], label='16')
+        plt.errorbar(azim_slices[50][0], azim_slices[50][1], yerr=azim_slices[50][2], label='50')
+        plt.legend()
+        plt.xlabel("Theta (rad)")
+        plt.ylabel("log Bispectrum")
+        plt.grid()
+        plt.tight_layout()
+        plt.savefig(osjoin(fig_path, "bispectrum_azim_slices.png"))
+        plt.close()
+
+
+    # Delta-Variance
+    if run_delvar:
+        from turbustat.statistics import DeltaVariance
+
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        moment0_err = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[1]
+
+        delvar = DeltaVariance(moment0, weights=moment0_err, distance=250 * u.pc)
+        delvar.run(verbose=True, xunit=u.pix,
+                   save_name=osjoin(fig_path, "delvar_design4.png"))
+
+        # Now with fitting limits
+        delvar.run(verbose=True, xunit=u.pix, xlow=4 * u.pix, xhigh=30 * u.pix,
+                   save_name=osjoin(fig_path, "delvar_design4_wlimits.png"))
+
+        # Now with fitting limits
+        delvar.run(verbose=True, xunit=u.pc, xlow=4 * u.pix, xhigh=30 * u.pix,
+                   save_name=osjoin(fig_path, "delvar_design4_physunits.png"))
+
+        delvar.run(verbose=True, xunit=u.pc, xlow=4 * u.pix, xhigh=40 * u.pix,
+                   brk=8 * u.pix,
+                   save_name=osjoin(fig_path, "delvar_design4_break.png"))
+
+        # Look at difference w/ non-periodic boundary handling
+        # This needs to be revisited with the astropy convolution updates
+        # delvar.run(verbose=True, xunit=u.pix, xlow=4 * u.pix, xhigh=30 * u.pix,
+        #            boundary='fill',
+        #            save_name=osjoin(fig_path, "delvar_design4_boundaryfill.png"))
+
+    # Dendrograms
+    if run_dendro:
+
+        from turbustat.statistics import Dendrogram_Stats
+        from astrodendro import Dendrogram
+
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+        d = Dendrogram.compute(cube.data, min_value=0.005, min_delta=0.1, min_npix=50,
+                               verbose=True)
+        ax = plt.subplot(111)
+        d.plotter().plot_tree(ax)
+        plt.ylabel("Intensity (K)")
+        plt.savefig(osjoin(fig_path, "design4_dendrogram.png"))
+        plt.close()
+
+        dend_stat = Dendrogram_Stats(cube, min_deltas=np.logspace(-2, 0, 50),
+                                     dendro_params={"min_value": 0.005,
+                                                    "min_npix": 50})
+
+        dend_stat.run(verbose=True,
+                      save_name=osjoin(fig_path, "design4_dendrogram_stats.png"))
+
+        # Periodic boundaries
+        dend_stat.run(verbose=True, periodic_bounds=True,
+                      save_name=osjoin(fig_path, "design4_dendrogram_stats_periodic.png"))
+
+    if run_genus:
+
+        from turbustat.statistics import Genus
+
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+
+        genus = Genus(moment0, lowdens_percent=15, highdens_percent=85, numpts=100,
+                      smoothing_radii=np.linspace(1, moment0.shape[0] / 10., 5))
+        genus.run(verbose=True, min_size=4, save_name=osjoin(fig_path, "genus_design4.png"))
+
+        # With min/max values.
+        genus = Genus(moment0, min_value=137, max_value=353, numpts=100,
+                      smoothing_radii=np.linspace(1, moment0.shape[0] / 10., 5))
+        genus.run(verbose=True, min_size=4, save_name=osjoin(fig_path, "genus_design4_minmaxval.png"))
+
+        # Requiring regions be larger than the beam
+        moment0.header["BMAJ"] = 2e-5  # deg.
+        genus = Genus(moment0, lowdens_percent=15, highdens_percent=85,
+                      smoothing_radii=[1] * u.pix)
+        genus.run(verbose=True, use_beam=True, save_name=osjoin(fig_path, "genus_design4_beamarea.png"))
+
+        # With a distance
+        genus = Genus(moment0, lowdens_percent=15, highdens_percent=85,
+                      smoothing_radii=u.Quantity([0.04 * u.pc]),
+                      distance=250 * u.pc)
+        genus.run(verbose=True, min_size=40 * u.AU**2,
+                  save_name=osjoin(fig_path, "genus_design4_physunits.png"))
+
+    # MVC
+    if run_mvc:
+
+        from turbustat.statistics import MVC
+
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        centroid = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_centroid.fits"))[0]
+        lwidth = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_linewidth.fits"))[0]
+
+        mvc = MVC(centroid, moment0, lwidth)
+        mvc.run(verbose=True, xunit=u.pix**-1,
+                save_name=osjoin(fig_path, 'mvc_design4.png'))
+
+        # With bounds
+        mvc.run(verbose=True, xunit=u.pix**-1, low_cut=0.02 / u.pix,
+                high_cut=0.1 / u.pix,
+                save_name=osjoin(fig_path, 'mvc_design4_limitedfreq.png'))
+
+        # With a break
+        mvc = MVC(centroid, moment0, lwidth, distance=250 * u.pc)
+        mvc.run(verbose=True, xunit=u.pix**-1, low_cut=0.02 / u.pix,
+                high_cut=0.4 / u.pix,
+                fit_kwargs=dict(brk=0.1 / u.pix), fit_2D=False,
+                save_name=osjoin(fig_path, "mvc_design4_breakfit.png"))
+
+        # With phys units
+        mvc = MVC(centroid, moment0, lwidth, distance=250 * u.pc)
+        mvc.run(verbose=True, xunit=u.pc**-1, low_cut=0.02 / u.pix,
+                high_cut=0.1 / u.pix, fit_2D=False,
+                save_name=osjoin(fig_path, 'mvc_design4_physunits.png'))
+
+        # Azimuthal limits
+        mvc = MVC(centroid, moment0, lwidth, distance=250 * u.pc)
+        mvc.run(verbose=True, xunit=u.pc**-1, low_cut=0.02 / u.pix,
+                high_cut=0.1 / u.pix, fit_2D=False,
+                radial_pspec_kwargs={"theta_0": 1.13 * u.rad, "delta_theta": 40 * u.deg},
+                save_name=osjoin(fig_path, 'mvc_design4_physunits_azimlimits.png'))
+
+    # PCA
+    if run_pca:
+
+        from turbustat.statistics import PCA
+
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+
+        pca = PCA(cube, distance=250. * u.pc)
+        pca.run(verbose=True, mean_sub=False,
+                min_eigval=1e-4, spatial_output_unit=u.pc,
+                spectral_output_unit=u.m / u.s,
+                beam_fwhm=10 * u.arcsec, brunt_beamcorrect=False,
+                save_name=osjoin(fig_path, "pca_design4_default.png"))
+
+        # With beam correction
+        pca.run(verbose=True, mean_sub=False,
+                min_eigval=1e-4, spatial_output_unit=u.pc,
+                spectral_output_unit=u.m / u.s,
+                beam_fwhm=10 * u.arcsec, brunt_beamcorrect=True,
+                save_name=osjoin(fig_path, "pca_design4_beamcorr.png"))
+
+        # With mean_sub
+        pca_ms = PCA(cube, distance=250. * u.pc)
+        pca_ms.run(verbose=True, mean_sub=True,
+                   min_eigval=1e-4, spatial_output_unit=u.pc,
+                   spectral_output_unit=u.m / u.s,
+                   beam_fwhm=10 * u.arcsec, brunt_beamcorrect=True,
+                   save_name=osjoin(fig_path, "pca_design4_meansub.png"))
+
+        # Individual steps
+
+        pca.compute_pca(mean_sub=False, n_eigs='auto', min_eigval=1.e-4, eigen_cut_method='value')
+        print(pca.n_eigs)
+
+        pca.compute_pca(mean_sub=False, n_eigs='auto', min_eigval=0.99, eigen_cut_method='proportion')
+        print(pca.n_eigs)
+
+        pca.compute_pca(mean_sub=False, n_eigs='auto', min_eigval=1.e-4, eigen_cut_method='value')
+        pca.find_spatial_widths(method='contour', beam_fwhm=10 * u.arcsec,
+                                brunt_beamcorrect=True, diagnosticplots=True)
+        plt.savefig(osjoin(fig_path, "pca_autocorrimgs_contourfit_Design4.png"))
+        plt.close()
+
+        pca.find_spectral_widths(method='walk-down')
+        autocorr_spec = pca.autocorr_spec()
+        x = np.fft.rfftfreq(500) * 500
+        fig, axes = plt.subplots(3, 3, sharex=True, sharey=True, figsize=(10, 8))
+        for i, ax in zip(range(9), axes.ravel()):
+            ax.plot(x, autocorr_spec[:251, i])
+            ax.axhline(np.exp(-1), label='exp(-1)', color='r', linestyle='--')
+            ax.axvline(pca.spectral_width(u.pix)[i].value,
+                       label='Fitted Width',
+                       color='g', linestyle='-.')
+            # ax.set_yticks([])
+            ax.set_title("{}".format(i + 1))
+            ax.set_xlim([0, 50])
+            if i == 0:
+                ax.legend()
+        fig.tight_layout()
+        fig.savefig(osjoin(fig_path, "pca_autocorrspec_Design4.png"))
+        plt.close()
+
+        pca.fit_plaw(fit_method='odr', verbose=True)
+        plt.savefig(osjoin(fig_path, "pca_design4_plaw_odr.png"))
+        plt.close()
+
+        pca.fit_plaw(fit_method='bayes', verbose=True)
+        plt.savefig(osjoin(fig_path, "pca_design4_plaw_mcmc.png"))
+        plt.close()
+
+        print(pca.gamma)
+
+        print(pca.sonic_length(T_k=10 * u.K, mu=1.36, unit=u.pc))
+
+    # PDF
+    if run_pdf:
+
+        from turbustat.statistics import PDF
+
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+        pdf_mom0 = PDF(moment0, min_val=0.0, bins=None)
+        pdf_mom0.run(verbose=True,
+                     save_name=osjoin(fig_path, "pdf_design4_mom0.png"))
+
+        print(pdf_mom0.find_percentile(500))
+        print(pdf_mom0.find_at_percentile(96.3134765625))
+
+        moment0_error = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[1]
+        pdf_mom0 = PDF(moment0, min_val=0.0, bins=None, weights=moment0_error.data**-2)
+        pdf_mom0.run(verbose=True,
+                     save_name=osjoin(fig_path, "pdf_design4_mom0_weights.png"))
+
+        pdf_mom0 = PDF(moment0, normalization_type='standardize')
+        pdf_mom0.run(verbose=True, do_fit=False,
+                     save_name=osjoin(fig_path, "pdf_design4_mom0_stand.png"))
+
+        pdf_mom0 = PDF(moment0, normalization_type='center')
+        pdf_mom0.run(verbose=True, do_fit=False,
+                     save_name=osjoin(fig_path, "pdf_design4_mom0_center.png"))
+
+        pdf_mom0 = PDF(moment0, normalization_type='normalize')
+        pdf_mom0.run(verbose=True, do_fit=False,
+                     save_name=osjoin(fig_path, "pdf_design4_mom0_norm.png"))
+
+        pdf_mom0 = PDF(moment0, normalization_type='normalize_by_mean')
+        pdf_mom0.run(verbose=True, do_fit=False,
+                     save_name=osjoin(fig_path, "pdf_design4_mom0_normmean.png"))
+
+        pdf_mom0 = PDF(moment0, min_val=0.0, bins=None)
+        pdf_mom0.run(verbose=True, fit_type='mcmc',
+                     save_name=osjoin(fig_path, "pdf_design4_mom0_mcmc.png"))
+
+        # Make a trace plot
+        pdf_mom0.trace_plot()
+        plt.savefig(osjoin(fig_path, "pdf_design4_mom0_mcmc_trace.png"))
+        plt.close()
+
+        # Make a corner plot
+        pdf_mom0.corner_plot(quantiles=[0.16, 0.5, 0.84])
+        plt.savefig(osjoin(fig_path, "pdf_design4_mom0_mcmc_corner.png"))
+        plt.close()
+
+        # Fit a power-law distribution
+        import scipy.stats as stats
+        pdf_mom0 = PDF(moment0, min_val=250.0, normalization_type=None)
+        pdf_mom0.run(verbose=True, model=stats.pareto, fit_type='mle', floc=False,
+                     save_name=osjoin(fig_path, "pdf_design4_mom0_plaw.png"))
+
+        cube = SpectralCube.read(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))
+        pdf_cube = PDF(cube)
+        pdf_cube.run(verbose=True, do_fit=False,
+                     save_name=osjoin(fig_path, "pdf_design4.png"))
+
+    # PSpec
+    if run_pspec:
+
+        from turbustat.statistics import PowerSpectrum
+
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+
+        pspec = PowerSpectrum(moment0, distance=250 * u.pc)
+        pspec.run(verbose=True, xunit=u.pix**-1,
+                  save_name=osjoin(fig_path, "design4_pspec.png"))
+
+        pspec.run(verbose=True, xunit=u.pix**-1,
+                  low_cut=0.025 / u.pix, high_cut=0.1 / u.pix,
+                  save_name=osjoin(fig_path, "design4_pspec_limitedfreq.png"))
+
+        print(pspec.slope2D, pspec.slope2D_err)
+        print(pspec.ellip2D, pspec.ellip2D_err)
+        print(pspec.theta2D, pspec.theta2D_err)
+
+        # How about fitting a break?
+        pspec = PowerSpectrum(moment0, distance=250 * u.pc)
+        pspec.run(verbose=True, xunit=u.pc**-1,
+                  low_cut=0.025 / u.pix, high_cut=0.4 / u.pix, fit_2D=False,
+                  fit_kwargs={'brk': 0.1 / u.pix, 'log_break': False},
+                  save_name=osjoin(fig_path, "design4_pspec_breakfit.png"))
+
+        pspec = PowerSpectrum(moment0, distance=250 * u.pc)
+        pspec.run(verbose=True, xunit=u.pc**-1,
+                  low_cut=0.025 / u.pix, high_cut=0.4 / u.pix, fit_2D=False,
+                  fit_kwargs={'brk': 0.1 / u.pix, 'log_break': False},
+                  radial_pspec_kwargs={"theta_0": 1.13 * u.rad, "delta_theta": 40 * u.deg},
+                  save_name=osjoin(fig_path, "design4_pspec_breakfit_azimlimits.png"))
+
+        pspec = PowerSpectrum(moment0, distance=250 * u.pc)
+        pspec.run(verbose=True, xunit=u.pix**-1,
+                  low_cut=0.025 / u.pix, high_cut=0.1 / u.pix,
+                  fit_kwargs={'weighted_fit': True},
+                  save_name=osjoin(fig_path, "design4_pspec_limitedfreq_weightfit.png"))
+
+
+    # SCF
+    if run_scf:
+
+        from turbustat.statistics import SCF
+
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+
+        scf = SCF(cube, size=11)
+        scf.run(verbose=True,
+                save_name=osjoin(fig_path, "design4_scf.png"))
+
+        print(scf.slope2D, scf.slope2D_err)
+        print(scf.ellip2D, scf.ellip2D_err)
+        print(scf.theta2D, scf.theta2D_err)
+
+        # With fit limits
+        scf.run(verbose=True, xlow=1 * u.pix, xhigh=5 * u.pix,
+                save_name=osjoin(fig_path, "design4_scf_fitlimits.png"))
+
+        # With azimuthal constraints
+        scf.run(verbose=True, xlow=1 * u.pix, xhigh=5 * u.pix,
+                radialavg_kwargs={"theta_0": 1.13 * u.rad, "delta_theta": 70 * u.deg},
+                save_name=osjoin(fig_path, "design4_scf_fitlimits_azimlimits.png"))
+
+
+        # Custom lags w/ phys units
+        distance = 250 * u.pc  # Assume a distance
+        phys_conv = (np.abs(cube.header['CDELT2']) * u.deg).to(u.rad).value * distance
+        custom_lags = np.arange(-4.5, 5, 1.5) * phys_conv
+        scf_physroll = SCF(cube, roll_lags=custom_lags, distance=distance)
+        scf_physroll.run(verbose=True, xunit=u.pc,
+                         save_name=osjoin(fig_path, "design4_scf_physroll.png"))
+
+        # boundary cut
+        scf = SCF(cube, size=11)
+        scf.run(verbose=True, boundary='cut',
+                save_name=osjoin(fig_path, "design4_scf_boundcut.png"))
+
+
+    # Moments
+    if run_moments:
+
+        from turbustat.statistics import StatMoments
+
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+
+        moments = StatMoments(moment0, radius=5 * u.pix)
+        moments.run(verbose=True, periodic=True,
+                    save_name=osjoin(fig_path, "design4_statmoments.png"))
+
+        moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists.png"))
+
+        # Demonstrate passing a weight array in
+        np.random.seed(3434789)
+        noise = moment0.data * 0.1 + np.random.normal(0, 0.1, size=moment0.data.shape)
+        moments_weighted = StatMoments(moment0, radius=5 * u.pix, weights=noise**-2)
+        moments_weighted.run(verbose=True, periodic=True,
+                             save_name=osjoin(fig_path, "design4_statmoments_randweights.png"))
+        moments_weighted.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_randweights.png"))
+
+        # Too small radius
+        moments.run(verbose=False, radius=2 * u.pix)
+        moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_rad_2pix.png"))
+
+        # Larger radius
+        moments.run(verbose=False, radius=10 * u.pix)
+        moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_rad_10pix.png"))
+
+        # Much larger radius
+        moments.run(verbose=False, radius=32 * u.pix)
+        moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_rad_32pix.png"))
+
+        # Other units
+        moments = StatMoments(moment0, radius=0.25 * u.pc, distance=250 * u.pc)
+        moments.run(verbose=False, periodic=True)
+        moments.plot_histograms(save_name=osjoin(fig_path, "design4_statmoments_hists_physunits.png"))
+
+    # Tsallis
+    if run_tsallis:
+        from turbustat.statistics import Tsallis
+
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+
+        tsallis = Tsallis(moment0).run(verbose=True,
+                                       save_name=osjoin(fig_path, 'design4_tsallis.png'))
+
+        # Tsallis parameters plot.
+        tsallis.plot_parameters(save_name=osjoin(fig_path, 'design4_tsallis_params.png'))
+
+        # With physical lags units
+        # Get a float rounding error, so just take first 3 decimal points
+        phys_lags = np.around(np.arange(0.025, 0.5, 0.05), 3) * u.pc
+        tsallis = Tsallis(moment0, lags=phys_lags, distance=250 * u.pc)
+        tsallis.run(verbose=True,
+                    save_name=osjoin(fig_path, 'design4_tsallis_physlags.png'))
+
+        # Not periodic
+        tsallis_noper = Tsallis(moment0).run(verbose=True, periodic=False,
+                                             save_name=osjoin(fig_path, 'design4_tsallis_noper.png'))
+
+        # Change sigma clip
+        tsallis = Tsallis(moment0).run(verbose=True, sigma_clip=3,
+                                       save_name=osjoin(fig_path, 'design4_tsallis_sigclip.png'))
+
+        tsallis.plot_parameters(save_name=osjoin(fig_path, 'design4_tsallis_params_sigclip.png'))
+
+    # VCA
+    if run_vca:
+
+        from turbustat.statistics import VCA
+
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+
+        vca = VCA(cube)
+        vca.run(verbose=True,
+                save_name=osjoin(fig_path, "design4_vca.png"))
+
+        vca.run(verbose=True, xunit=u.pix**-1, low_cut=0.02 / u.pix, high_cut=0.1 / u.pix,
+                save_name=osjoin(fig_path, "design4_vca_limitedfreq.png"))
+
+        vca = VCA(cube, distance=250 * u.pc)
+        vca.run(verbose=True, xunit=u.pc**-1, low_cut=0.02 / u.pix,
+                high_cut=0.4 / u.pix,
+                fit_kwargs=dict(brk=0.1 / u.pix), fit_2D=False,
+                save_name=osjoin(fig_path, "design4_vca_breakfit.png"))
+
+        vca_thicker = VCA(cube, distance=250 * u.pc, channel_width=400 * u.m / u.s)
+        vca_thicker.run(verbose=True, xunit=u.pc**-1, low_cut=0.02 / u.pix,
+                        high_cut=0.4 / u.pix,
+                        fit_kwargs=dict(brk=0.1 / u.pix), fit_2D=False,
+                        save_name=osjoin(fig_path, "design4_vca_400ms_channels.png"))
+
+        # W/ azimuthal constraints
+        vca = VCA(cube)
+        vca.run(verbose=True, xunit=u.pix**-1, low_cut=0.02 / u.pix, high_cut=0.1 / u.pix,
+                radial_pspec_kwargs={"theta_0": 1.13 * u.rad, "delta_theta": 40 * u.deg},
+                save_name=osjoin(fig_path, "design4_vca_limitedfreq_azimilimits.png"))
+
+
+    # VCS
+    if run_vcs:
+
+        from turbustat.statistics import VCS
+
+        cube = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc.fits"))[0]
+
+        vcs = VCS(cube)
+        vcs.run(verbose=True,
+                save_name=osjoin(fig_path, "design4_vcs.png"))
+
+        vcs.run(verbose=True, high_cut=0.17 / u.pix,
+                save_name=osjoin(fig_path, "design4_vcs_lowcut.png"))
+
+        vcs.run(verbose=True, high_cut=0.17 / u.pix, xunit=(u.m / u.s)**-1,
+                save_name=osjoin(fig_path, "design4_vcs_lowcut_physunits.png"))
+
+        vcs.run(verbose=True, high_cut=0.17 / u.pix, low_cut=6e-4 / (u.m / u.s), xunit=(u.m / u.s)**-1,
+                save_name=osjoin(fig_path, "design4_vcs_bothcut_physunits.png"))
+
+    # Wavelets
+    if run_wavelet:
+        from turbustat.statistics import Wavelet
+
+        moment0 = fits.open(osjoin(data_path, "Design4_flatrho_0021_00_radmc_moment0.fits"))[0]
+
+        wavelet = Wavelet(moment0).run(verbose=True,
+                                       save_name=osjoin(fig_path, 'design4_wavelet.png'))
+
+        # Limit the range
+        wavelet = Wavelet(moment0)
+        wavelet.run(verbose=True, xlow=1 * u.pix, xhigh=10 * u.pix,
+                    save_name=osjoin(fig_path, 'design4_wavelet_fitlimits.png'))
+
+        phys_scales = np.arange(0.025, 0.5, 0.05) * u.pc
+        wavelet = Wavelet(moment0, distance=250 * u.pc, scales=phys_scales)
+        wavelet.run(verbose=True, xlow=1 * u.pix, xhigh=10 * u.pix, xunit=u.pc,
+                    save_name=osjoin(fig_path, 'design4_wavelet_physunits.png'))
+
+        wavelet = Wavelet(moment0)
+        wavelet.run(verbose=True, scale_normalization=False, xhigh=10 * u.pix,
+                    save_name=osjoin(fig_path, 'design4_wavelet_unnorm.png'))

--- a/turbustat/statistics/mvc/mvc.py
+++ b/turbustat/statistics/mvc/mvc.py
@@ -46,8 +46,8 @@ class MVC(BaseStatisticMixIn, StatisticBase_PSpec2D):
                  distance=None, beam=None):
 
         # data property not used here
-        self.no_data_flag = True
-        self.data = None
+        # self.no_data_flag = True
+        # self.data = None
 
         if header is None:
             try:
@@ -61,6 +61,8 @@ class MVC(BaseStatisticMixIn, StatisticBase_PSpec2D):
         else:
             self._centroid = input_data(centroid, no_header=True)
             self.header = header
+
+        self.data = self.centroid
 
         if distance is not None:
             self.distance = distance
@@ -187,20 +189,10 @@ class MVC(BaseStatisticMixIn, StatisticBase_PSpec2D):
         # Shift to the center
         mvc_fft = fftshift(mvc_fft)
 
-        if beam_correct:
-            if not hasattr(self, '_beam'):
-                raise AttributeError("Beam correction cannot be applied since"
-                                     " no beam object was given.")
-
-            beam_kern = self._beam.as_kernel(self._ang_size,
-                                             y_size=self.centroid.shape[0],
-                                             x_size=self.centroid.shape[1])
-
-            beam_fft = fftshift(rfft_to_fft(beam_kern.array))
-
-            self._beam_pow = np.abs(beam_fft**2)
-
         self._ps2D = np.abs(mvc_fft) ** 2.
+
+        if beam_correct:
+            self.compute_beam_pspec()
 
         if beam_correct:
             self._ps2D /= self._beam_pow

--- a/turbustat/statistics/psds.py
+++ b/turbustat/statistics/psds.py
@@ -129,8 +129,12 @@ def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
     else:
         azim_mask = None
 
-    ps1D, bin_edge, cts = binned_statistic(dist_arr[azim_mask].ravel(),
-                                           psd2[azim_mask].ravel(),
+    finite_mask = np.isfinite(psd2)
+    if azim_mask is not None:
+        finite_mask = np.logical_and(finite_mask, azim_mask)
+
+    ps1D, bin_edge, cts = binned_statistic(dist_arr[finite_mask].ravel(),
+                                           psd2[finite_mask].ravel(),
                                            bins=bins,
                                            statistic=mean_func)
 
@@ -153,15 +157,15 @@ def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
             stat_func = lambda data: np.mean(bootstrap(data, boot_iter,
                                                        bootfunc=np.std))
 
-        ps1D_stddev = binned_statistic(dist_arr[azim_mask].ravel(),
-                                       psd2[azim_mask].ravel(),
+        ps1D_stddev = binned_statistic(dist_arr[finite_mask].ravel(),
+                                       psd2[finite_mask].ravel(),
                                        bins=bins,
                                        statistic=stat_func)[0]
 
         # We're dealing with variations in the number of samples for each bin.
         # Add a correction based on the t distribution
-        bin_cts = binned_statistic(dist_arr[azim_mask].ravel(),
-                                   psd2[azim_mask].ravel(),
+        bin_cts = binned_statistic(dist_arr[finite_mask].ravel(),
+                                   psd2[finite_mask].ravel(),
                                    bins=bins,
                                    statistic='count')[0]
 

--- a/turbustat/statistics/pspec_bispec/bispec.py
+++ b/turbustat/statistics/pspec_bispec/bispec.py
@@ -233,6 +233,9 @@ class Bispectrum(BaseStatisticMixIn):
             raise TypeError("value must be 'bispectrum'"
                             ", 'bispectrum_logamp', or 'bicoherence'")
 
+        # Keep a finite value array for binned_statistic for scipy >1.14
+        finite_mask = np.isfinite(value_arr)
+
         if isinstance(radii, np.ndarray) or isinstance(radii, list):
             if not isinstance(delta_radii, np.ndarray):
                 delta_radii = np.array([delta_radii] * len(radii))
@@ -270,13 +273,13 @@ class Bispectrum(BaseStatisticMixIn):
             mask = np.logical_and(dist >= rad - del_rad / 2.,
                                   dist <= rad + del_rad / 2.)
 
-            vals, bin_edge, cts = binned_statistic(theta[mask].ravel(),
-                                                   value_arr[mask].ravel(),
+            vals, bin_edge, cts = binned_statistic(theta[mask & finite_mask].ravel(),
+                                                   value_arr[mask & finite_mask].ravel(),
                                                    bins=bins,
                                                    statistic=np.nanmean)
 
-            stds, bin_edge, cts = binned_statistic(theta[mask].ravel(),
-                                                   value_arr[mask].ravel(),
+            stds, bin_edge, cts = binned_statistic(theta[mask & finite_mask].ravel(),
+                                                   value_arr[mask & finite_mask].ravel(),
                                                    bins=bins,
                                                    statistic=np.nanstd)
 
@@ -331,6 +334,9 @@ class Bispectrum(BaseStatisticMixIn):
             raise TypeError("value must be 'bispectrum'"
                             ", 'bispectrum_logamp', or 'bicoherence'")
 
+        # Keep a finite value array for binned_statistic for scipy >1.14
+        finite_mask = np.isfinite(value_arr)
+
         orig_thetas = thetas.copy().value
 
         # Check units
@@ -376,13 +382,13 @@ class Bispectrum(BaseStatisticMixIn):
             mask = np.logical_and(theta_arr >= theta - del_theta / 2.,
                                   theta_arr <= theta + del_theta / 2.)
 
-            vals, bin_edge, cts = binned_statistic(dist[mask].ravel(),
-                                                   value_arr[mask].ravel(),
+            vals, bin_edge, cts = binned_statistic(dist[mask & finite_mask].ravel(),
+                                                   value_arr[mask & finite_mask].ravel(),
                                                    bins=bins,
                                                    statistic=np.nanmean)
 
-            stds, bin_edge, cts = binned_statistic(dist[mask].ravel(),
-                                                   value_arr[mask].ravel(),
+            stds, bin_edge, cts = binned_statistic(dist[mask & finite_mask].ravel(),
+                                                   value_arr[mask & finite_mask].ravel(),
                                                    bins=bins,
                                                    statistic=np.nanstd)
 

--- a/turbustat/statistics/pspec_bispec/pspec.py
+++ b/turbustat/statistics/pspec_bispec/pspec.py
@@ -109,20 +109,10 @@ class PowerSpectrum(BaseStatisticMixIn, StatisticBase_PSpec2D):
                                    threads=threads,
                                    **pyfftw_kwargs))
 
-        if beam_correct:
-            if not hasattr(self, '_beam'):
-                raise AttributeError("Beam correction cannot be applied since"
-                                     " no beam object was given.")
-
-            beam_kern = self._beam.as_kernel(self._ang_size,
-                                             y_size=self.data.shape[0],
-                                             x_size=self.data.shape[1])
-
-            beam_fft = fftshift(rfft_to_fft(beam_kern.array))
-
-            self._beam_pow = np.abs(beam_fft**2)
-
         self._ps2D = np.power(fft, 2.)
+
+        if beam_correct:
+            self.compute_beam_pspec()
 
         if beam_correct:
             self._ps2D /= self._beam_pow

--- a/turbustat/statistics/vca_vcs/vca.py
+++ b/turbustat/statistics/vca_vcs/vca.py
@@ -115,20 +115,10 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
                                    threads=threads,
                                    **pyfftw_kwargs))
 
-        if beam_correct:
-            if not hasattr(self, '_beam'):
-                raise AttributeError("Beam correction cannot be applied since"
-                                     " no beam object was given.")
-
-            beam_kern = self._beam.as_kernel(self._ang_size,
-                                             y_size=self.data.shape[1],
-                                             x_size=self.data.shape[2])
-
-            beam_fft = fftshift(rfft_to_fft(beam_kern.array))
-
-            self._beam_pow = np.abs(beam_fft**2)
-
         self._ps2D = np.power(fft, 2.).sum(axis=0)
+
+        if beam_correct:
+            self.compute_beam_pspec()
 
         if beam_correct:
             self._ps2D /= self._beam_pow


### PR DESCRIPTION
`binned_statistic` in scipy 1.14 now checks for non-finite values. Previously, we were using `nanmean`/`nanstd` to avoid NaNs in the inputs.

This PR masks the input data before passing it to `binned_statistic`.

Also, I moved computing the beam power spectrum to its own function for the power spectrum-based methods.