### PR TITLE
Fix for Tsallis chi squared values with scipy 1.7

### DIFF
--- a/turbustat/statistics/tsallis/tsallis.py
+++ b/turbustat/statistics/tsallis/tsallis.py
@@ -195,9 +195,7 @@ class Tsallis(BaseStatisticMixIn):
             fitted_vals = tsallis_function(clipped[0], *params)
             self._tsallis_params[i] = params
             self._tsallis_stderrs[i] = np.sqrt(np.diag(pcov))
-            self._tsallis_chisq[i] = chisquare(np.exp(fitted_vals),
-                                               f_exp=np.exp(clipped[1]),
-                                               ddof=3)[0]
+            self._tsallis_chisq[i] = np.sum((np.exp(fitted_vals) - np.exp(clipped[1]))**2. / np.exp(clipped[1]))
 
     @property
     def tsallis_params(self):


### PR DESCRIPTION
As of scipy 1.7, explicit tests for the correctness of the Chisq test are included in `scipy.stats.chisquare`. We are only using the chisquare value and do not need the full test.