### PR TITLE
Update testing to drop 3.6 and add 3.9, 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,10 @@
 name: Run tests
 
-# on:
-#   push:
-#   pull_request:
-#   schedule:
-#     - cron: '12 0 * * 1'  # every Monday at 12 pm
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '12 0 * * 1'  # every Monday at 12 pm
 
 jobs:
   tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Installing fftw for py39
-      if: ${{ contains(matrix.toxenv,'py39') }}
+    - name: Installing fftw for py39 - ubuntu
+      if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}
       run: sudo apt-get install libfftw3-dev
     - name: Install testing dependencies
       run: python -m pip install tox codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.8
             name: Python 3.8 with minimal dependencies
-            toxenv: py37-test
+            toxenv: py38-test
 
           - os: ubuntu-latest
             python-version: 3.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
     - name: Installing fftw for py39 - ubuntu
       if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}
       run: sudo apt-get install libfftw3-dev
+      run: python -m pip install cython
     - name: Install testing dependencies
       run: python -m pip install tox codecov
     - name: Run tests with ${{ matrix.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: Run tests
 
-on:
-  push:
-  pull_request:
-  schedule:
-    - cron: '12 0 * * 1'  # every Monday at 12 pm
+# on:
+#   push:
+#   pull_request:
+#   schedule:
+#     - cron: '12 0 * * 1'  # every Monday at 12 pm
 
 jobs:
   tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,19 +15,24 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            python-version: 3.9
+            name: Python 3.9 with minimal dependencies
+            toxenv: py39-test
+
+          - os: ubuntu-latest
+            python-version: 3.8
+            name: Python 3.8 with minimal dependencies
+            toxenv: py37-test
+
+          - os: ubuntu-latest
             python-version: 3.7
             name: Python 3.7 with minimal dependencies
             toxenv: py37-test
 
-          - os: ubuntu-18.04
-            python-version: 3.6
-            name: Python 3.6 with minimal dependencies
-            toxenv: py36-test
-
           - os: ubuntu-latest
-            python-version: 3.7
-            name: Python 3.7 with all dependencies
-            toxenv: py37-test-all
+            python-version: 3.9
+            name: Python 3.9 with all dependencies
+            toxenv: py39-test-all-cov
 
           - os: ubuntu-latest
             python-version: 3.8
@@ -35,9 +40,9 @@ jobs:
             toxenv: py38-test-dev
 
           - os: macos-latest
-            python-version: 3.7
-            name: Python 3.7 with all dependencies, and dev versions of key dependencies on MacOS X
-            toxenv: py37-test-all-dev
+            python-version: 3.9
+            name: Python 3.9 with all dependencies, and dev versions of key dependencies on MacOS X
+            toxenv: py39-test-all-dev
 
           # - os: windows-latest
           #   python-version: 3.7
@@ -45,7 +50,7 @@ jobs:
           #   toxenv: py37-test-all-dev
 
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
             name: Documentation
             toxenv: build_docs
 
@@ -60,6 +65,7 @@ jobs:
     - name: Run tests with ${{ matrix.name }}
       run: tox -v -e ${{ matrix.toxenv }}
     - name: Upload coverage to codecov
+      if: ${{ contains(matrix.toxenv,'-cov') }}
       uses: codecov/codecov-action@v1.0.13
       with:
         file: ./coverage.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,8 +67,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Installing fftw for py39 - ubuntu
       if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}
-      run: sudo apt-get install libfftw3-dev
-      run: python -m pip install cython
+      run: |
+        sudo apt-get install libfftw3-dev
+        python -m pip install cython
     - name: Install testing dependencies
       run: python -m pip install tox codecov
     - name: Run tests with ${{ matrix.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,15 +49,10 @@ jobs:
             name: Python 3.9 with all dependencies, and dev versions of key dependencies on MacOS X
             toxenv: py39-test-all-dev
 
-          - os: macos-latest
+          - os: windows-latest
             python-version: 3.9
-            name: Python 3.9 with minimal dependencies on MacOS X
-            toxenv: py39-test
-
-          # - os: windows-latest
-          #   python-version: 3.7
-          #   name: Python 3.7, all dependencies, and dev versions of key dependencies on Windows
-          #   toxenv: py37-test-all-dev
+            name: Python 3.9, all dependencies, and dev versions of key dependencies on Windows
+            toxenv: py39-test-all-dev
 
           - os: ubuntu-latest
             python-version: 3.9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,10 +66,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Installing fftw for py39 - ubuntu
-      if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}
+      if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') && contains(matrix.toxenv,'all')}}
       run: |
         sudo apt-get install libfftw3-dev
         python -m pip install cython
+        python -m pip install pyfftw
     - name: Install testing dependencies
       run: python -m pip install tox codecov
     - name: Run tests with ${{ matrix.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            python-version: '3.10'
+            name: Python 3.10 with minimal dependencies
+            toxenv: py39-test
+
+          - os: ubuntu-latest
             python-version: 3.9
             name: Python 3.9 with minimal dependencies
             toxenv: py39-test
@@ -35,14 +40,14 @@ jobs:
             toxenv: py39-test-all-cov
 
           - os: ubuntu-latest
-            python-version: 3.8
-            name: Python 3.8, all dependencies, and dev versions of key dependencies
-            toxenv: py38-test-dev
+            python-version: 3.9
+            name: Python 3.9, all dependencies, and dev versions of key dependencies
+            toxenv: py39-test-dev
 
           - os: macos-latest
-            python-version: 3.8
-            name: Python 3.8 with all dependencies, and dev versions of key dependencies on MacOS X
-            toxenv: py38-test-all-dev
+            python-version: 3.9
+            name: Python 3.9 with all dependencies, and dev versions of key dependencies on MacOS X
+            toxenv: py39-test-all-dev
 
           - os: macos-latest
             python-version: 3.9
@@ -65,12 +70,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Installing fftw for py39 - ubuntu
-      if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') && contains(matrix.toxenv,'all')}}
-      run: |
-        sudo apt-get install libfftw3-dev
-        python -m pip install cython
-        python -m pip install pyfftw
     - name: Install testing dependencies
       run: python -m pip install tox codecov
     - name: Run tests with ${{ matrix.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             name: Python 3.10 with minimal dependencies
-            toxenv: py39-test
+            toxenv: py310-test
 
           - os: ubuntu-latest
             python-version: 3.9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ name: Run tests
 #   pull_request:
 #   schedule:
 #     - cron: '12 0 * * 1'  # every Monday at 12 pm
+on: [push, pull_request]
 
 jobs:
   tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,14 @@ jobs:
             toxenv: py38-test-dev
 
           - os: macos-latest
+            python-version: 3.8
+            name: Python 3.8 with all dependencies, and dev versions of key dependencies on MacOS X
+            toxenv: py38-test-all-dev
+
+          - os: macos-latest
             python-version: 3.9
-            name: Python 3.9 with all dependencies, and dev versions of key dependencies on MacOS X
-            toxenv: py39-test-all-dev
+            name: Python 3.9 with minimal dependencies on MacOS X
+            toxenv: py39-test
 
           # - os: windows-latest
           #   python-version: 3.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Installing fftw for py39
       if: ${{ contains(matrix.toxenv,'py39') }}
-      run: sudo apt-get install libfftw3
+      run: sudo apt-get install libfftw3-dev
     - name: Install testing dependencies
       run: python -m pip install tox codecov
     - name: Run tests with ${{ matrix.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Installing fftw for py39
+      if: ${{ contains(matrix.toxenv,'py39') }}
+      run: sudo apt-get install libfftw3
     - name: Install testing dependencies
       run: python -m pip install tox codecov
     - name: Run tests with ${{ matrix.name }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,9 +15,11 @@ jobs:
         name: Install Python
         with:
           python-version: '3.7'
+      - name: Installing fftw for py39 - ubuntu
+        if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}
+        run: sudo apt-get install libfftw3-dev
       - name: Install cibuildwheel
         run: |
-          sudo apt-get install libfftw3-dev
           python -m pip install --upgrade pip
           python -m pip install cibuildwheel
       - name: Build wheels

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Installing libjpeg and pillow - ubuntu
         if: ${{ contains(matrix.os,'ubuntu') }}
         run: |
-          sudo apt-get installlibjpeg-dev
+          sudo apt-get install libjpeg-dev
           python -m pip install Pillow
       - name: Installing fftw for py39 - ubuntu
         if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: '3.7'
       - name: Install cibuildwheel
         run: |
-          sudo apt-get install libfftw3
+          sudo apt-get install libfftw3-dev
           python -m pip install --upgrade pip
           python -m pip install cibuildwheel
       - name: Build wheels

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
+
   build_wheels_macosx:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -103,7 +104,7 @@ jobs:
 
   upload_pypi:
     name: Upload to PyPI
-    needs: [build_wheels, build_sdist, build_wheels_windows]
+    needs: [build_wheels_linux, build_wheels_macosx, build_wheels_windows, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Installing fftw for py39 - ubuntu
         if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}
         run: sudo apt-get install libfftw3-dev
+        run: python -m pip install cython
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -23,6 +23,32 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
+          CIBW_TEST_EXTRAS: test
+          CIBW_TEST_COMMAND: pytest --pyargs turbustat
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_wheels_windows:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: cp37-* cp38-* cp39-*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
       - uses: actions/upload-artifact@v2
@@ -50,7 +76,7 @@ jobs:
 
   upload_pypi:
     name: Upload to PyPI
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist, build_wheels_windows]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           sudo apt-get install libfftw3-dev
           python -m pip install cython
+          python -m pip install pyfftw
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,18 +14,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
-      - name: Installing libjpeg and pillow - ubuntu
-        if: ${{ contains(matrix.os,'ubuntu') }}
-        run: |
-          sudo apt-get install libjpeg-dev
-          python -m pip install Pillow
-      - name: Installing fftw for py39 - ubuntu
-        if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}
-        run: |
-          sudo apt-get install libfftw3-dev
-          python -m pip install cython
-          python -m pip install pyfftw
+          python-version: '3.9'
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
@@ -33,7 +22,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp37-* cp38-* cp39-*
+          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
@@ -22,7 +22,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp37-* cp38-*
+          CIBW_BUILD: cp37-* cp38-* cp39-*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
       - uses: actions/upload-artifact@v2
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: Install build
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.7'
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install build
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,12 +3,38 @@ name: Build and upload to PyPI
 on: [push, pull_request]
 
 jobs:
-  build_wheels:
+  build_wheels_linux:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64
+          CIBW_TEST_EXTRAS: test
+          CIBW_TEST_COMMAND: pytest --pyargs turbustat
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_wheels_macosx:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -28,6 +54,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+
 
   build_wheels_windows:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,6 +15,11 @@ jobs:
         name: Install Python
         with:
           python-version: '3.7'
+      - name: Installing libjpeg and pillow - ubuntu
+        if: ${{ contains(matrix.os,'ubuntu') }}
+        run: |
+          sudo apt-get installlibjpeg-dev
+          python -m pip install Pillow
       - name: Installing fftw for py39 - ubuntu
         if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,8 +17,9 @@ jobs:
           python-version: '3.7'
       - name: Installing fftw for py39 - ubuntu
         if: ${{ contains(matrix.toxenv,'py39') && contains(matrix.os,'ubuntu') }}
-        run: sudo apt-get install libfftw3-dev
-        run: python -m pip install cython
+        run: |
+          sudo apt-get install libfftw3-dev
+          python -m pip install cython
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,6 +17,7 @@ jobs:
           python-version: '3.7'
       - name: Install cibuildwheel
         run: |
+          sudo apt-get install libfftw3
           python -m pip install --upgrade pip
           python -m pip install cibuildwheel
       - name: Build wheels
@@ -37,7 +38,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.8'
       - name: Install build
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,5 @@ requires = ["setuptools",
             "wheel",
             "extension-helpers",
             "oldest-supported-numpy",
-            "cython==0.29.14"]
+            "cython"]
 build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,9 @@ install_requires =
     scikit-image>=0.12
     spectral_cube
 
+[extension-helpers]
+use_extension_helpers = true
+
 [options.extras_require]
 test =
     pytest-astropy

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,6 @@
 import os
 import sys
 
-import numpy
-
-from setuptools import setup
-from setuptools.extension import Extension
-
 TEST_HELP = """
 Note: running tests is no longer done using 'python setup.py test'. Instead
 you will need to run:
@@ -40,7 +35,4 @@ if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
     print(DOCS_HELP)
     sys.exit(1)
 
-setup(use_scm_version={'write_to': os.path.join('turbustat', 'version.py')},
-      ext_modules=[Extension("turbustat.simulator.spectrum",
-                  [os.path.join('turbustat', 'spectrum', 'spectrum.pyx')],
-                  include_dirs=[numpy.get_include()])])
+setup(use_scm_version={'write_to': os.path.join('turbustat', 'version.py')})

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 import os
 import sys
 from setuptools import setup
-from extension_helpers import get_extensions
 
 TEST_HELP = """
 Note: running tests is no longer done using 'python setup.py test'. Instead
@@ -37,5 +36,4 @@ if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
     print(DOCS_HELP)
     sys.exit(1)
 
-setup(use_scm_version={'write_to': os.path.join('turbustat', 'version.py')},
-      ext_modules=get_extensions())
+setup(use_scm_version={'write_to': os.path.join('turbustat', 'version.py')})

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,11 @@
 
 import os
 import sys
+
+import numpy
+
 from setuptools import setup
+from setuptools.extension import Extension
 
 TEST_HELP = """
 Note: running tests is no longer done using 'python setup.py test'. Instead
@@ -36,4 +40,7 @@ if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
     print(DOCS_HELP)
     sys.exit(1)
 
-setup(use_scm_version={'write_to': os.path.join('turbustat', 'version.py')})
+setup(use_scm_version={'write_to': os.path.join('turbustat', 'version.py')},
+      ext_modules=[Extension("turbustat.simulator.spectrum",
+                  [os.path.join('turbustat', 'spectrum', 'spectrum.pyx')],
+                  include_dirs=[numpy.get_include()])])

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+from setuptools import setup
+
 TEST_HELP = """
 Note: running tests is no longer done using 'python setup.py test'. Instead
 you will need to run:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39}-test{,-all,-dev,-cov}
+    py{37,38,39,310}-test{,-all,-dev,-cov}
     build_docs
     codestyle
 requires =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-all,-dev}
+    py{37,38,39}-test{,-all,-dev,-cov}
     build_docs
     codestyle
 requires =
@@ -32,8 +32,9 @@ extras =
     all: all
 commands =
     pip freeze
-    pytest --open-files --pyargs turbustat {toxinidir}/docs --cov turbustat --cov-config={toxinidir}/setup.cfg {posargs}
-    coverage xml -o {toxinidir}/coverage.xml
+    !cov: pytest --open-files --pyargs turbustat {toxinidir}/docs {posargs}
+    cov: pytest --open-files --pyargs turbustat {toxinidir}/docs --cov turbustat --cov-config={toxinidir}/setup.cfg {posargs}
+    cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:build_docs]
 changedir =


### PR DESCRIPTION
Tests started failing due to a mismatch in python 3.7 and dev requirements. This updates the testing versions to fix that.