### PR TITLE
Updates and fixes to Genus + numpy slice fixes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,7 @@ Many thanks to everyone who has reported bugs and given feedback on TurbuStat!
 * Jonathan Henshaw
 * Sac Medina
 * Andrés Izquierdo
+* Kaya Mori
 
 
 Contents:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -26,14 +26,11 @@ The following packages are optional when installing TurbuStat and are required o
  *   `emcee <http://dan.iel.fm/emcee/current/>`_ - MCMC fitting in `~turbustat.statistics.PCA` and `~turbustat.statistics.PDF`.
  *   `pyfftw <https://hgomersall.github.io/pyFFTW/>`_ - Wrapper for the FFTW libraries. Allows FFTs to be run in parallel.
 
-Install TurbuStat with:
 
-    >>> pip install turbustat
-
-Otherwise, clone the repository::
+To install the development version, clone the repository::
     >>> git clone https://github.com/Astroua/TurbuStat # doctest: +SKIP
 
-Change into the TurbuStat directory and run the following to install TurbuStat::
+Change into the TurbuStat directory and run::
     >>> pip install -e . # doctest: +SKIP
 
 If you find any issues in the installation, please make an `issue on github <https://github.com/Astroua/TurbuStat/issues>`_ or contact the developers at the email on `this page <https://github.com/e-koch>`_. Thank you!

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,13 +10,13 @@ TurbuStat can also be installed from the `github repository <https://github.com/
 
 TurbuStat requires the follow packages:
 
- *   astropy>=2.0
- *   numpy>=1.7
- *   matplotlib>=1.2
- *   scipy>=0.12
- *   sklearn>=0.13.0
- *   statsmodels>=0.4.0
- *   scikit-image>=0.12
+ *   astropy
+ *   numpy
+ *   matplotlib
+ *   scipy
+ *   scikit-learn
+ *   statsmodels
+ *   scikit-image
 
 The following packages are optional when installing TurbuStat and are required only for specific functions in TurbuStat:
 
@@ -26,11 +26,15 @@ The following packages are optional when installing TurbuStat and are required o
  *   `emcee <http://dan.iel.fm/emcee/current/>`_ - MCMC fitting in `~turbustat.statistics.PCA` and `~turbustat.statistics.PDF`.
  *   `pyfftw <https://hgomersall.github.io/pyFFTW/>`_ - Wrapper for the FFTW libraries. Allows FFTs to be run in parallel.
 
- To install TurbuStat, clone the repository::
+Install TurbuStat with:
+
+    >>> pip install turbustat
+
+Otherwise, clone the repository::
     >>> git clone https://github.com/Astroua/TurbuStat # doctest: +SKIP
 
 Change into the TurbuStat directory and run the following to install TurbuStat::
-    >>> python setup.py install # doctest: +SKIP
+    >>> pip install -e . # doctest: +SKIP
 
 If you find any issues in the installation, please make an `issue on github <https://github.com/Astroua/TurbuStat/issues>`_ or contact the developers at the email on `this page <https://github.com/e-koch>`_. Thank you!
 

--- a/turbustat/io/input_base.py
+++ b/turbustat/io/input_base.py
@@ -57,11 +57,11 @@ def input_data(data, no_header=False, need_copy=False):
     if HAS_SC:
         sc_def = False
         if isinstance(data, SpectralCube):
-            output_data = [make_copy(data.filled_data[:].value, need_copy),
+            output_data = [make_copy(data.filled_data[:], need_copy),
                            data.header]
             sc_def = True
         elif isinstance(data, LowerDimensionalObject):
-            output_data = [make_copy(data.value, need_copy), data.header]
+            output_data = [make_copy(data, need_copy), data.header]
             sc_def = True
     else:
         sc_def = False

--- a/turbustat/moments/_moment_errs.py
+++ b/turbustat/moments/_moment_errs.py
@@ -242,11 +242,12 @@ def _slice0(cube, axis, scale):
 
     for i in range(cube.shape[axis]):
         view[axis] = i
-        plane = cube._mask.include(data=cube._data, wcs=cube._wcs, view=view)
+        plane = cube._mask.include(data=cube._data, wcs=cube._wcs,
+                                   view=tuple(view))
         valid |= plane
 
         if _scale_cube:
-            noise_plane = np.nan_to_num(scale.filled_data[view])
+            noise_plane = np.nan_to_num(scale.filled_data[tuple(view)])
         else:
             noise_plane = scale
 
@@ -305,11 +306,11 @@ def _slice1(cube, axis, scale, moment0, moment1):
     for i in range(cube.shape[axis]):
         view[axis] = i
 
-        term1 = pix_cen[view] / axis_sum
+        term1 = pix_cen[tuple(view)] / axis_sum
 
         if _scale_cube:
             noise_plane = \
-                np.nan_to_num(scale.filled_data[view])
+                np.nan_to_num(scale.filled_data[tuple(view)])
         else:
             noise_plane = scale
 
@@ -365,19 +366,19 @@ def _slice2(cube, axis, scale, moment0, moment1, moment2,
 
     for i in range(cube.shape[axis]):
         view[axis] = i
-        plane = np.nan_to_num(cube.filled_data[view])
+        plane = np.nan_to_num(cube.filled_data[tuple(view)])
 
-        term11 = np.power((pix_cen[view] - moment1), 2) / axis_sum
+        term11 = np.power((pix_cen[tuple(view)] - moment1), 2) / axis_sum
 
         if _scale_cube:
             noise_plane = \
-                np.nan_to_num(scale.filled_data[view])
+                np.nan_to_num(scale.filled_data[tuple(view)])
         else:
             noise_plane = scale
 
         term1 += np.power((term11 - term12) * noise_plane, 2)
 
-        term2 += np.nan_to_num(plane) * (pix_cen[view] - moment1)
+        term2 += np.nan_to_num(plane) * (pix_cen[tuple(view)] - moment1)
 
     term2 = 4 * np.power((moment1_err * term2) / (axis_sum), 2)
 

--- a/turbustat/simulator/make_cube.py
+++ b/turbustat/simulator/make_cube.py
@@ -254,4 +254,4 @@ def field_slice(y, x, los_axis):
 
     spat_slices.insert(los_axis, los_slice)
 
-    return spat_slices
+    return tuple(spat_slices)

--- a/turbustat/simulator/tests/test_ppv.py
+++ b/turbustat/simulator/tests/test_ppv.py
@@ -25,9 +25,10 @@ def test_ppv(axis):
     # Number of samples to take along each non-projected dimension
     size = 16
 
-    twod_slice = [slice(0, size), slice(0, size)]
+    twod_slice = (slice(0, size), slice(0, size))
     threed_slice = [slice(0, size), slice(0, size)]
     threed_slice.insert(axis, slice(None))
+    threed_slice = tuple(threed_slice)
 
     # Need a large enough field to have good statistics
     velocity = make_3dfield(128, powerlaw=3.5, amp=5.e3) * u.m / u.s
@@ -93,9 +94,10 @@ def test_ppv_negative_density():
 
     axis = 0
 
-    twod_slice = [slice(0, size), slice(0, size)]
+    twod_slice = (slice(0, size), slice(0, size))
     threed_slice = [slice(0, size), slice(0, size)]
     threed_slice.insert(axis, slice(None))
+    threed_slice = tuple(threed_slice)
 
     # Need a large enough field to have good statistics
     velocity = make_3dfield(128, powerlaw=3.5, amp=5.e3) * u.m / u.s

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -412,8 +412,12 @@ class StatisticBase_PSpec2D(object):
             ellip_conv = 0
             p0 = (amp_guess, ellip_conv, theta, slope_guess)
 
+        fit_values = np.log10(self.ps2D[mask])
+        if isinstance(fit_values, u.Quantity):
+            fit_values = fit_values.value
+
         params, stderrs, fit_2Dmodel, fitter = \
-            fit_elliptical_powerlaw(np.log10(self.ps2D[mask]),
+            fit_elliptical_powerlaw(fit_values,
                                     xx_freq[mask],
                                     yy_freq[mask], p0,
                                     fit_method=fit_method,

--- a/turbustat/statistics/genus/genus.py
+++ b/turbustat/statistics/genus/genus.py
@@ -673,3 +673,30 @@ def remove_small_objects(arr, min_size, connectivity=2):
         arr[posns] = 0
 
     return arr
+
+
+def model_gaussian_genus(x, A, theta_C):
+    '''
+    Analytic Genus model for a Gaussian field using the formalism from
+    Coles (1988) (https://ui.adsabs.harvard.edu/abs/1988MNRAS.234..509C/abstract).
+
+    .. note:: The A and theta_C parameters will be degenerate as they set the
+    normalization of the Genus curve, not its shape.
+
+    Parameters
+    ----------
+    x : numpy.ndarray or float
+        Standardized value ((val - mean) / std).
+    A : float
+        A is the area of the total field. For a 2D image with uncorrelated
+        noise, this is equal to the number of pixels. With correlated values,
+        this will be closer to the number of independent regions.
+    theta_C : float
+        theta_C is the 'coherence angle' and will be close to the width of a
+        2D Gaussian matching the spatial correlation scale (i.e., the beam or
+        PSF width).
+
+    '''
+    return (A / theta_C**2) * x * np.exp(-x**2 / 2.) / (2 * np.pi)**1.5
+
+

--- a/turbustat/statistics/genus/genus.py
+++ b/turbustat/statistics/genus/genus.py
@@ -356,7 +356,7 @@ class Genus(BaseStatisticMixIn):
 
         genus_tables = []
 
-        for ii, radii in enumerate(self.smoothing_radii):
+        for ii, radius in enumerate(self.smoothing_radius):
 
             tab = Table()
             tab.add_column(Column(self.thresholds, name='thresholds'))
@@ -368,16 +368,27 @@ class Genus(BaseStatisticMixIn):
             else:
                 mean_vals = np.array([mean_val] * len(self.thresholds))
 
+            tab.add_column(Column(mean_vals, name='data_mean'))
+
             std_val = self.smoothed_stds[ii]
             if hasattr(std_val, 'unit'):
                 std_vals = ([std_val.value] * len(self.thresholds)) * std_val.unit
             else:
                 std_vals = np.array([std_val] * len(self.thresholds))
 
-            tab.add_column(Column(mean_vals, name='data_mean'))
             tab.add_column(Column(std_vals, name='data_std'))
 
             genus_tables.append(tab)
+
+            if hasattr(radius, 'unit'):
+                radius_vals = ([radius.value] * len(self.thresholds)) * radius.unit
+            else:
+                radius_vals = np.array([radius] * len(self.thresholds))
+
+            tab.add_column(Column(radius_vals, name='smooth_radius'))
+
+            genus_tables.append(tab)
+
 
         return genus_tables
 

--- a/turbustat/statistics/genus/genus.py
+++ b/turbustat/statistics/genus/genus.py
@@ -230,9 +230,9 @@ class Genus(BaseStatisticMixIn):
         return self._smoothed_stds
 
 
-    def make_genus_curve(self, enable_small_removal=False,
+    def make_genus_curve(self, enable_small_removal=True,
                          use_beam=False, min_size=4,
-                         connectivity=1,
+                         connectivity=2,
                          keep_smoothed_images=False,
                          match_kernel=False,
                          **convolution_kwargs):

--- a/turbustat/statistics/genus/genus.py
+++ b/turbustat/statistics/genus/genus.py
@@ -356,7 +356,7 @@ class Genus(BaseStatisticMixIn):
 
         genus_tables = []
 
-        for ii, radius in enumerate(self.smoothing_radius):
+        for ii, radius in enumerate(self.smoothing_radii):
 
             tab = Table()
             tab.add_column(Column(self.thresholds, name='thresholds'))

--- a/turbustat/statistics/genus/genus.py
+++ b/turbustat/statistics/genus/genus.py
@@ -260,6 +260,25 @@ class Genus(BaseStatisticMixIn):
         '''
         return self._genus_stats
 
+    def make_genus_stats_table(self):
+        '''
+        Returns an astropy table with genus curve and thresholds with 1 table per
+        smoothed image.
+        '''
+        from astropy.table import Table, Column
+
+        genus_tables = []
+
+        for ii, radii in enumerate(self.smoothing_radii):
+
+            tab = Table()
+            tab.add_column(Column(self.thresholds, name='thresholds'))
+            tab.add_column(Column(self.genus_stats[ii], name='genus_value'))
+
+            genus_tables.append(tab)
+
+        return genus_tables
+
     def plot_fit(self, save_name=None, color='r', symbol='o'):
         '''
         Plot the Genus curves.

--- a/turbustat/statistics/genus/genus.py
+++ b/turbustat/statistics/genus/genus.py
@@ -82,45 +82,46 @@ class Genus(BaseStatisticMixIn):
             self.distance = distance
 
         if min_value is None:
-            min_value = np.nanmin(self.data)
-        else:
-            if hasattr(self.data, 'unit'):
-                if not hasattr(min_value, 'unit'):
-                    raise TypeError("data has units of {}. 'min_value' must "
-                                    "have equivalent units."
-                                    .format(self.data.unit))
-                if not min_value.unit.is_equivalent(self.data.unit):
-                    raise u.UnitsError("min_value does not have an equivalent "
-                                       "units to the img unit.")
 
-                min_value = min_value.to(self.data.unit)
+            if lowdens_percent == 0.0:
+                min_value = np.nanmin(self.data)
+            else:
+                min_value = np.nanpercentile(self.data, lowdens_percent)
+
+            if not hasattr(min_value, 'unit') and hasattr(self.data, 'unit'):
+                min_value *= self.data.unit
+
+        if hasattr(self.data, 'unit'):
+            if not hasattr(min_value, 'unit'):
+                raise TypeError("data has units of {}. 'min_value' must "
+                                "have equivalent units."
+                                .format(self.data.unit))
+            if not min_value.unit.is_equivalent(self.data.unit):
+                raise u.UnitsError("min_value does not have an equivalent "
+                                    "units to the img unit.")
+
+            min_value = min_value.to(self.data.unit)
 
         if max_value is None:
-            max_value = np.nanmax(self.data)
-        else:
-            if hasattr(self.data, 'unit'):
-                if not hasattr(max_value, 'unit'):
-                    raise TypeError("data has units of {}. 'max_value' must "
-                                    "have equivalent units."
-                                    .format(self.data.unit))
-                if not max_value.unit.is_equivalent(self.data.unit):
-                    raise u.UnitsError("max_value does not have an equivalent "
-                                       "units to the img unit.")
 
-                max_value = max_value.to(self.data.unit)
+            if highdens_percent == 100.0:
+                max_value = np.nanmax(self.data)
+            else:
+                max_value = np.nanpercentile(self.data, highdens_percent)
 
-        min_percent = \
-            np.percentile(self.data[~np.isnan(self.data)],
-                          lowdens_percent)
-        max_percent = \
-            np.percentile(self.data[~np.isnan(self.data)],
-                          highdens_percent)
+            if not hasattr(max_value, 'unit') and hasattr(self.data, 'unit'):
+                max_value *= self.data.unit
 
-        if min_value is None or min_percent > min_value:
-            min_value = min_percent
+        if hasattr(max_value, 'unit') and hasattr(self.data, 'unit'):
+            if not hasattr(max_value, 'unit'):
+                raise TypeError("data has units of {}. 'max_value' must "
+                                "have equivalent units."
+                                .format(self.data.unit))
+            if not max_value.unit.is_equivalent(self.data.unit):
+                raise u.UnitsError("max_value does not have an equivalent "
+                                    "units to the img unit.")
 
-        if max_value is None or max_percent > max_value:
-            max_value = max_percent
+            max_value = max_value.to(self.data.unit)
 
         self._thresholds = np.linspace(min_value, max_value, numpts)
 

--- a/turbustat/statistics/genus/genus.py
+++ b/turbustat/statistics/genus/genus.py
@@ -290,6 +290,10 @@ class Genus(BaseStatisticMixIn):
         self._smoothed_means = np.empty(len(self.smoothing_radii))
         self._smoothed_stds = np.empty(len(self.smoothing_radii))
 
+        if hasattr(self.data, 'unit'):
+            self._smoothed_means *= self.data.unit
+            self._smoothed_stds *= self.data.unit
+
         conn_kernel = nd.generate_binary_structure(2, connectivity)
 
         for j, width in enumerate(self.smoothing_radii):


### PR DESCRIPTION
This PR fixes various smaller bugs and makes running/saving the results of the Genus statistic easier.

* [x] Optional data smoothing
* [x] Export table files with genus statistics
* [x] Fix setting min/max values for thresholds to consider
* [x] Add custom threshold array to use
* [x] Fix size related issues when comparing to the Gaussian noise case (thanks to Kaya Mori for identifying and reporting the problem!)
* [x] Also fixing the slice by list errors that are now raised in the newest numpy versions.

Note that the "size" related issue was related to using the original image threshold values compared to the smoothed image. The default is to smooth the image by a 1 pixel wide Gaussian (this PR enables a no smoothing option), thereby lowering the standard deviation compared to the original image.

To fix this, we now record the mean and std for each smoothed/original image with `Genus.smoothed_means`, `Genus.smoothed_stds`. These correspond to the imaged smoothed by kernels defined in `Genus.smoothing_radii`. These mean/std values are what should be used to plot/fit the standardized values in a Genus curve (where standardized here is `zscore = (value - mean) / std`).
