### PR TITLE
Add unbinned power spectrum fitting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            python-version: '3.11'
+            name: Python 3.11 with minimal dependencies
+            toxenv: py311-test
+
+          - os: ubuntu-latest
             python-version: '3.10'
             name: Python 3.10 with minimal dependencies
             toxenv: py310-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,9 @@ jobs:
             toxenv: build_docs
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install testing dependencies
@@ -71,6 +71,6 @@ jobs:
       run: tox -v -e ${{ matrix.toxenv }}
     - name: Upload coverage to codecov
       if: ${{ contains(matrix.toxenv,'-cov') }}
-      uses: codecov/codecov-action@v1.0.13
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.9'
@@ -25,7 +25,7 @@ jobs:
           CIBW_BUILD: cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -37,8 +37,8 @@ jobs:
       matrix:
         os: [macos-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.9'
@@ -52,7 +52,7 @@ jobs:
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -64,8 +64,8 @@ jobs:
       matrix:
         os: [windows-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.9'
@@ -79,7 +79,7 @@ jobs:
           CIBW_BUILD: cp37-* cp38-* cp39-*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -87,8 +87,8 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.9'
@@ -98,7 +98,7 @@ jobs:
           python -m pip install build
       - name: Build sdist
         run: python -m build --sdist --outdir dist/ .
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
@@ -22,7 +22,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64
+          CIBW_BUILD: cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
       - uses: actions/upload-artifact@v3
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
@@ -49,7 +49,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
+          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
       - uses: actions/upload-artifact@v3
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
@@ -76,7 +76,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp37-* cp38-* cp39-*
+          CIBW_BUILD: cp39-* cp310-* cp311-*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
       - uses: actions/upload-artifact@v3
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install build
         run: |
           python -m pip install --upgrade pip
@@ -112,7 +112,7 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,17 +10,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.11'
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install cibuildwheel
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_BUILD: cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64
           CIBW_TEST_EXTRAS: test
@@ -37,17 +33,13 @@ jobs:
       matrix:
         os: [macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.11'
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install cibuildwheel
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-*
           CIBW_TEST_EXTRAS: test
@@ -64,19 +56,15 @@ jobs:
       matrix:
         os: [windows-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.11'
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install cibuildwheel
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_BUILD: cp39-* cp310-* cp311-*
+          CIBW_BUILD: cp39-*win_amd64 cp310-*win_amd64 cp311-*win_amd64
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs turbustat
       - uses: actions/upload-artifact@v3
@@ -87,7 +75,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         name: Install Python
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ docs/api
 *.pyc
 
 *.DS_Store
+*.ipynb_checkpoints
 
 turbustat/version.py
 turbustat/cython_version.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ testpaths = "turbustat" "docs"
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
-addopts = --doctest-rst
+addopts = --doctest-rst -p no:warnings
 
 [coverage:run]
 omit =

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,8 @@ extras =
     all: all
 commands =
     pip freeze
-    !cov: pytest --open-files --pyargs turbustat {toxinidir}/docs {posargs}
-    cov: pytest --open-files --pyargs turbustat {toxinidir}/docs --cov turbustat --cov-config={toxinidir}/setup.cfg {posargs}
+    !cov: pytest --pyargs turbustat {toxinidir}/docs {posargs}
+    cov: pytest --pyargs turbustat {toxinidir}/docs --cov turbustat --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:build_docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-all,-dev,-cov}
+    py{37,38,39,310,311}-test{,-all,-dev,-cov}
     build_docs
     codestyle
 requires =

--- a/turbustat/moments/_moment_errs.py
+++ b/turbustat/moments/_moment_errs.py
@@ -238,7 +238,7 @@ def _slice0(cube, axis, scale):
     result = np.zeros(shp) * cube.unit ** 2
 
     view = [slice(None)] * 3
-    valid = np.zeros(shp, dtype=np.bool)
+    valid = np.zeros(shp, dtype=bool)
 
     for i in range(cube.shape[axis]):
         view[axis] = i

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -106,7 +106,7 @@ class StatisticBase_PSpec2D(object):
         # Attach units to freqs
         self._freqs = self.freqs / u.pix
 
-    def fit_pspec(self, fit_unbinned=True,
+    def fit_pspec(self, fit_unbinned=False,
                   brk=None, log_break=False, low_cut=None,
                   high_cut=None, min_fits_pts=10, weighted_fit=False,
                   bootstrap=False, bootstrap_kwargs={},
@@ -219,6 +219,10 @@ class StatisticBase_PSpec2D(object):
 
             y_err = 0.434 * clipped_stddev / clipped_ps1D
 
+            weights = 1 / y_err**2
+        else:
+            weights = None
+
         if brk is not None:
             # Try the fit with a break in it.
             if not log_break:
@@ -229,11 +233,6 @@ class StatisticBase_PSpec2D(object):
                 if hasattr(brk, "unit"):
                     assert brk.unit == u.dimensionless_unscaled
                     brk = brk.value
-
-            if weighted_fit:
-                weights = 1 / y_err**2
-            else:
-                weights = None
 
             brk_fit = Lm_Seg(x, y, brk, weights=weights)
             brk_fit.fit_model(verbose=verbose, cov_type='HC3')

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -106,7 +106,8 @@ class StatisticBase_PSpec2D(object):
         # Attach units to freqs
         self._freqs = self.freqs / u.pix
 
-    def fit_pspec(self, brk=None, log_break=False, low_cut=None,
+    def fit_pspec(self, fit_unbinned=True,
+                  brk=None, log_break=False, low_cut=None,
                   high_cut=None, min_fits_pts=10, weighted_fit=False,
                   bootstrap=False, bootstrap_kwargs={},
                   verbose=False):
@@ -118,6 +119,10 @@ class StatisticBase_PSpec2D(object):
 
         Parameters
         ----------
+        fit_unbinned : bool, optional
+            Fits the unbinned 2D power-spectrum to the linear model. Default is True.
+            Use False to fit the binned 1D power-spectrum instead and replicate fitting
+            in earlier TurbuStat versions.
         brk : float or None, optional
             Guesses for the break points. If given as a list, the length of
             the list sets the number of break points to be fit. If a choice is
@@ -150,29 +155,62 @@ class StatisticBase_PSpec2D(object):
 
         self._bootstrap_flag = bootstrap
 
-        # Make the data to fit to
-        if low_cut is None:
-            # Default to the largest frequency, since this is just 1 pixel
-            # in the 2D PSpec.
-            self.low_cut = 1. / (0.5 * float(max(self.ps2D.shape)) * u.pix)
+        if fit_unbinned:
+            yy_freq, xx_freq = make_radial_freq_arrays(self.ps2D.shape)
+
+            freqs_2d = np.sqrt(yy_freq**2 + xx_freq**2) / u.pix
+
+            # Make the data to fit to
+            if low_cut is None:
+                # Default to the largest frequency, since this is just 1 pixel
+                # in the 2D PSpec.
+                self.low_cut = 1. / (0.5 * float(max(self.ps2D.shape)) * u.pix)
+            else:
+                self.low_cut = self._to_pixel_freq(low_cut)
+
+            if high_cut is None:
+                # self.high_cut = self.freqs.max().value / u.pix
+                self.high_cut = freqs_2d.value.max() / u.pix
+            else:
+                self.high_cut = self._to_pixel_freq(high_cut)
+
+
+            clip_mask = clip_func(freqs_2d.value,
+                                self.low_cut.value,
+                                self.high_cut.value)
+
+
+            x = np.log10(freqs_2d.value[clip_mask])
+            y = np.log10(self.ps2D[clip_mask])
+
         else:
-            self.low_cut = self._to_pixel_freq(low_cut)
+            # Make the data to fit to
+            if low_cut is None:
+                # Default to the largest frequency, since this is just 1 pixel
+                # in the 2D PSpec.
+                self.low_cut = 1. / (0.5 * float(max(self.ps2D.shape)) * u.pix)
+            else:
+                self.low_cut = self._to_pixel_freq(low_cut)
 
-        if high_cut is None:
-            self.high_cut = self.freqs.max().value / u.pix
-        else:
-            self.high_cut = self._to_pixel_freq(high_cut)
+            if high_cut is None:
+                self.high_cut = self.freqs.max().value / u.pix
+            else:
+                self.high_cut = self._to_pixel_freq(high_cut)
 
-        x = np.log10(self.freqs[clip_func(self.freqs.value, self.low_cut.value,
-                                          self.high_cut.value)].value)
+            x = np.log10(self.freqs[clip_func(self.freqs.value, self.low_cut.value,
+                                            self.high_cut.value)].value)
 
-        clipped_ps1D = self.ps1D[clip_func(self.freqs.value,
-                                           self.low_cut.value,
-                                           self.high_cut.value)]
-        y = np.log10(clipped_ps1D)
+            clipped_ps1D = self.ps1D[clip_func(self.freqs.value,
+                                            self.low_cut.value,
+                                            self.high_cut.value)]
+            y = np.log10(clipped_ps1D)
 
         if weighted_fit:
+            if fit_unbinned:
+                raise NotImplementedError("Error propagation for the unbinned modeling is not "
+                                          "implemented yet.")
 
+            # Currently this will run only for the binned fitting.
             clipped_stddev = self.ps1D_stddev[clip_func(self.freqs.value,
                                                         self.low_cut.value,
                                                         self.high_cut.value)]
@@ -246,7 +284,7 @@ class StatisticBase_PSpec2D(object):
             x = sm.add_constant(x)
 
             if weighted_fit:
-                model = sm.WLS(y, x, missing='drop', weights=1 / y_err**2)
+                model = sm.WLS(y, x, missing='drop', weights=weights)
             else:
                 model = sm.OLS(y, x, missing='drop')
 
@@ -614,8 +652,6 @@ class StatisticBase_PSpec2D(object):
         good_interval = clip_func(self.freqs.value, self.low_cut.value,
                                   self.high_cut.value)
 
-        y_fit = self.fit.fittedvalues
-
         if show_residual:
             if isinstance(self.slope, np.ndarray):
                 # Broken linear model
@@ -679,7 +715,11 @@ class StatisticBase_PSpec2D(object):
                                    fmt=symbol, markersize=5, alpha=0.5,
                                    capsize=10, elinewidth=3)
 
-        ax_1D.plot(np.log10(xvals[fit_index]), y_fit, linestyle='-',
+        xvals_plot = np.log10(xvals[fit_index]).ravel()
+        # y_fit = self.fit.fittedvalues
+        y_fit = self.fit.predict(sm.add_constant(xvals_plot))
+
+        ax_1D.plot(xvals_plot, y_fit, linestyle='-',
                    label=label, linewidth=3, color=fit_color)
 
         if show_residual:

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -88,7 +88,7 @@ class StatisticBase_PSpec2D(object):
         '''
 
         # Check if azimuthal constraints are given
-        if kwargs.get("theta_0"):
+        if "theta_0" in kwargs:
             azim_constraint_flag = True
         else:
             azim_constraint_flag = False

--- a/turbustat/statistics/mvc/mvc.py
+++ b/turbustat/statistics/mvc/mvc.py
@@ -229,7 +229,8 @@ class MVC(BaseStatisticMixIn, StatisticBase_PSpec2D):
             use_pyfftw=False, threads=1, pyfftw_kwargs={},
             radial_pspec_kwargs={},
             low_cut=None, high_cut=None,
-            fit_2D=True, fit_kwargs={}, fit_2D_kwargs={},
+            fit_kwargs={}, fit_unbinned=False,
+            fit_2D=True, fit_2D_kwargs={},
             save_name=None, xunit=u.pix**-1, use_wavenumber=False):
         '''
         Full computation of MVC. For fitting parameters and radial binning
@@ -253,10 +254,12 @@ class MVC(BaseStatisticMixIn, StatisticBase_PSpec2D):
             Low frequency cut off in frequencies used in the fitting.
         high_cut : `~astropy.units.Quantity`, optional
             High frequency cut off in frequencies used in the fitting.
-        fit_2D : bool, optional
-            Fit an elliptical power-law model to the 2D power spectrum.
         fit_kwargs : dict, optional
             Passed to `~PowerSpectrum.fit_pspec`.
+        fit_unbinned : bool, optional
+            Passed to `~PowerSpectrum.fit_pspec`. Default is False.
+        fit_2D : bool, optional
+            Fit an elliptical power-law model to the 2D power spectrum.
         fit_2D_kwargs : dict, optional
             Keyword arguments for `~MVC.fit_2Dpspec`. Use the
             `low_cut` and `high_cut` keywords to provide fit limits.
@@ -280,7 +283,9 @@ class MVC(BaseStatisticMixIn, StatisticBase_PSpec2D):
                            **pyfftw_kwargs)
 
         self.compute_radial_pspec(**radial_pspec_kwargs)
-        self.fit_pspec(low_cut=low_cut, high_cut=high_cut, **fit_kwargs)
+        self.fit_pspec(low_cut=low_cut, high_cut=high_cut,
+                       fit_unbinned=fit_unbinned,
+                       **fit_kwargs)
 
         if fit_2D:
             self.fit_2Dpspec(low_cut=low_cut, high_cut=high_cut,

--- a/turbustat/statistics/pspec_bispec/bispec.py
+++ b/turbustat/statistics/pspec_bispec/bispec.py
@@ -114,8 +114,8 @@ class Bispectrum(BaseStatisticMixIn):
 
         bispec_shape = (int(self.shape[0] / 2.), int(self.shape[1] / 2.))
 
-        self._bispectrum = np.zeros(bispec_shape, dtype=np.complex)
-        self._bicoherence = np.zeros(bispec_shape, dtype=np.float)
+        self._bispectrum = np.zeros(bispec_shape, dtype=complex)
+        self._bicoherence = np.zeros(bispec_shape, dtype=float)
         self._tracker = np.zeros(self.shape, dtype=np.int16)
 
         biconorm = np.ones_like(self.bispectrum, dtype=float)

--- a/turbustat/statistics/pspec_bispec/pspec.py
+++ b/turbustat/statistics/pspec_bispec/pspec.py
@@ -122,9 +122,9 @@ class PowerSpectrum(BaseStatisticMixIn, StatisticBase_PSpec2D):
             apodize_kernel=None, alpha=0.2, beta=0.0,
             use_pyfftw=False, threads=1,
             pyfftw_kwargs={},
-            low_cut=None, high_cut=None,
-            fit_2D=True, radial_pspec_kwargs={}, fit_kwargs={},
-            fit_2D_kwargs={},
+            low_cut=None, high_cut=None, radial_pspec_kwargs={},
+            fit_kwargs={}, fit_unbinned=False,
+            fit_2D=True, fit_2D_kwargs={},
             xunit=u.pix**-1, save_name=None,
             use_wavenumber=False):
         '''
@@ -157,12 +157,14 @@ class PowerSpectrum(BaseStatisticMixIn, StatisticBase_PSpec2D):
             Low frequency cut off in frequencies used in the fitting.
         high_cut : `~astropy.units.Quantity`, optional
             High frequency cut off in frequencies used in the fitting.
-        fit_2D : bool, optional
-            Fit an elliptical power-law model to the 2D power spectrum.
         radial_pspec_kwargs : dict, optional
             Passed to `~PowerSpectrum.compute_radial_pspec`.
         fit_kwargs : dict, optional
             Passed to `~PowerSpectrum.fit_pspec`.
+        fit_unbinned : bool, optional
+            Passed to `~PowerSpectrum.fit_pspec`. Default is False.
+        fit_2D : bool, optional
+            Fit an elliptical power-law model to the 2D power spectrum.
         fit_2D_kwargs : dict, optional
             Keyword arguments for `PowerSpectrum.fit_2Dpspec`. Use the
             `low_cut` and `high_cut` keywords to provide fit limits.
@@ -178,6 +180,10 @@ class PowerSpectrum(BaseStatisticMixIn, StatisticBase_PSpec2D):
         if pyfftw_kwargs.get('threads') is not None:
             pyfftw_kwargs.pop('threads')
 
+        # Pop fit_unbinned if given as kwarg in dict.
+        if fit_kwargs.get('fit_unbinned') is not None:
+            fit_kwargs.pop('fit_unbinned')
+
         self.compute_pspec(apodize_kernel=apodize_kernel,
                            alpha=alpha, beta=beta,
                            beam_correct=beam_correct,
@@ -186,7 +192,9 @@ class PowerSpectrum(BaseStatisticMixIn, StatisticBase_PSpec2D):
 
         self.compute_radial_pspec(**radial_pspec_kwargs)
 
-        self.fit_pspec(low_cut=low_cut, high_cut=high_cut, **fit_kwargs)
+        self.fit_pspec(fit_unbinned=fit_unbinned,
+                       low_cut=low_cut, high_cut=high_cut,
+                       **fit_kwargs)
 
         if fit_2D:
             self.fit_2Dpspec(low_cut=low_cut, high_cut=high_cut,

--- a/turbustat/statistics/scf/scf.py
+++ b/turbustat/statistics/scf/scf.py
@@ -258,12 +258,12 @@ class SCF(BaseStatisticMixIn):
         if self.scf_surface is None:
             self.compute_surface()
 
-        if kwargs.get("logspacing"):
+        if "logspacing" in kwargs:
             warn("Disabled log-spaced bins. This does not work well for the"
                  " SCF.", TurbuStatMetricWarning)
             kwargs.pop('logspacing')
 
-        if kwargs.get("theta_0"):
+        if "theta_0" in kwargs:
             azim_constraint_flag = True
         else:
             azim_constraint_flag = False

--- a/turbustat/statistics/vca_vcs/vca.py
+++ b/turbustat/statistics/vca_vcs/vca.py
@@ -129,7 +129,8 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
             pyfftw_kwargs={},
             radial_pspec_kwargs={},
             low_cut=None, high_cut=None,
-            fit_2D=True, fit_kwargs={}, fit_2D_kwargs={},
+            fit_kwargs={}, fit_unbinned=False,
+            fit_2D=True,  fit_2D_kwargs={},
             save_name=None, xunit=u.pix**-1, use_wavenumber=False):
         '''
         Full computation of VCA.
@@ -163,10 +164,12 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
             Low frequency cut off in frequencies used in the fitting.
         high_cut : `~astropy.units.Quantity`, optional
             High frequency cut off in frequencies used in the fitting.
-        fit_2D : bool, optional
-            Fit an elliptical power-law model to the 2D power spectrum.
         fit_kwargs : dict, optional
             Passed to `~PowerSpectrum.fit_pspec`.
+        fit_unbinned : bool, optional
+            Passed to `~PowerSpectrum.fit_pspec`. Default is False.
+        fit_2D : bool, optional
+            Fit an elliptical power-law model to the 2D power spectrum.
         fit_2D_kwargs : dict, optional
             Keyword arguments for `~VCA.fit_2Dpspec`. Use the
             `low_cut` and `high_cut` keywords to provide fit limits.
@@ -183,6 +186,10 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
         if pyfftw_kwargs.get('threads') is not None:
             pyfftw_kwargs.pop('threads')
 
+        # Pop fit_unbinned if given as kwarg in dict.
+        if fit_kwargs.get('fit_unbinned') is not None:
+            fit_kwargs.pop('fit_unbinned')
+
         self.compute_pspec(apodize_kernel=apodize_kernel,
                            alpha=alpha, beta=beta,
                            beam_correct=beam_correct,
@@ -190,7 +197,8 @@ class VCA(BaseStatisticMixIn, StatisticBase_PSpec2D):
                            **pyfftw_kwargs)
 
         self.compute_radial_pspec(**radial_pspec_kwargs)
-        self.fit_pspec(low_cut=low_cut, high_cut=high_cut, **fit_kwargs)
+        self.fit_pspec(low_cut=low_cut, high_cut=high_cut, fit_unbinned=fit_unbinned,
+                       **fit_kwargs)
 
         if fit_2D:
             self.fit_2Dpspec(low_cut=low_cut, high_cut=high_cut,

--- a/turbustat/statistics/wavelets/wavelet_transform.py
+++ b/turbustat/statistics/wavelets/wavelet_transform.py
@@ -152,7 +152,7 @@ class Wavelet(BaseStatisticMixIn):
         A = len(self.scales)
 
         if keep_convolved_arrays:
-            self._Wf = np.zeros((A, n0, m0), dtype=np.float)
+            self._Wf = np.zeros((A, n0, m0), dtype=float)
         else:
             self._Wf = None
 

--- a/turbustat/tests/test_pspec.py
+++ b/turbustat/tests/test_pspec.py
@@ -203,13 +203,13 @@ def test_pspec_unbin_vs_bin(plaw):
                         return_fft=False)
 
     test = PowerSpectrum(fits.PrimaryHDU(img))
-    test.run(fit_kwargs={'fit_unbinned': True},
+    test.run(fit_unbinned=True,
              fit_2D=False)
 
     # Ensure slopes are consistent to within 2%
     npt.assert_allclose(-plaw, test.slope, rtol=0.02)
 
-    test.run(fit_kwargs={'fit_unbinned': False},
+    test.run(fit_unbinned=False,
              fit_2D=False)
 
     # Ensure slopes are consistent to within 2%

--- a/turbustat/tests/test_pspec.py
+++ b/turbustat/tests/test_pspec.py
@@ -187,6 +187,35 @@ def test_pspec_weightfit(plaw):
     npt.assert_allclose(-plaw, test.slope, rtol=0.02)
 
 
+@pytest.mark.parametrize('plaw', np.arange(0.5, 5, 0.67))
+def test_pspec_unbin_vs_bin(plaw):
+    '''
+    The slopes with azimuthal constraints should be the same. When elliptical,
+    the power will be different along the different directions, but the slope
+    should remain the same.
+    '''
+
+    imsize = 64
+    theta = 0
+
+    # Generate a red noise model
+    img = make_extended(imsize, powerlaw=plaw, ellip=1., theta=theta,
+                        return_fft=False)
+
+    test = PowerSpectrum(fits.PrimaryHDU(img))
+    test.run(fit_kwargs={'fit_unbinned': True},
+             fit_2D=False)
+
+    # Ensure slopes are consistent to within 2%
+    npt.assert_allclose(-plaw, test.slope, rtol=0.02)
+
+    test.run(fit_kwargs={'fit_unbinned': False},
+             fit_2D=False)
+
+    # Ensure slopes are consistent to within 2%
+    npt.assert_allclose(-plaw, test.slope, rtol=0.02)
+
+
 @pytest.mark.parametrize('theta',
                          [0., np.pi / 4., np.pi / 2., 7 * np.pi / 8.])
 def test_pspec_fit2D(theta):

--- a/turbustat/tests/test_wavelet.py
+++ b/turbustat/tests/test_wavelet.py
@@ -67,7 +67,7 @@ def test_Wavelet_method_failbreak():
 
     # No break and only 1 slope
     assert tester.brk is None
-    assert isinstance(tester.slope, np.float)
+    assert isinstance(tester.slope, float)
 
 
 def test_Wavelet_method_fitlimits():


### PR DESCRIPTION
The radial binning has a bias that we've recently found comparing against infilled maps of WISE. It's not yet clear where the issue is in the binning since the baseline tests against a known powerlaw image pass.

To alleviate this problem, this PR adds an option to fit a 1D model to the unbinned data, which returns fitted indices similar to the 2D elliptical power law fit (for an isotropic field).

Also incorporated as #244 and added testing for python 3.11. Dropped builds for python 3.7 following various dependencies.

