### PR TITLE
Removing np.NaN removed in numpy v2.0

### DIFF
--- a/docs/preparing_simulated_data.rst
+++ b/docs/preparing_simulated_data.rst
@@ -65,7 +65,7 @@ A common observational practice is to mask noise-only regions of an image or dat
     >>> signal_mask = noisy_cube > N * sigma
     >>> # Set all places below the noise threshold to NaN in the cube
     >>> masked_cube = signal_mask.copy()
-    >>> masked_cube[~signal_mask] = np.NaN
+    >>> masked_cube[~signal_mask] = np.nan
 
 TurbuStat does not contain routines to create robust signal masks. Examples of creating signal masks can be found in `Rosolowsky & Leroy 2006 <https://ui.adsabs.harvard.edu/#abs/2006PASP..118..590R/abstract>`_ and `Dame 2011 <https://ui.adsabs.harvard.edu/#abs/2011arXiv1101.1499D/abstract>`_.
 

--- a/docs/tutorials/code_for_examples.py
+++ b/docs/tutorials/code_for_examples.py
@@ -378,7 +378,7 @@ if RUN_CODE:
         # Mask some of the data out
 
         masked_img = img.copy()
-        masked_img[masked_img < np.percentile(img, 25)] = np.NaN
+        masked_img[masked_img < np.percentile(img, 25)] = np.nan
 
         plt.imshow(masked_img, origin='lower')
         plt.colorbar()
@@ -412,7 +412,7 @@ if RUN_CODE:
         from scipy import ndimage as nd
         labs, num = nd.label(np.isfinite(padded_masked_img), np.ones((3, 3)))
         # Keep the largest regions
-        padded_masked_img[np.where(labs > 1)] = np.NaN
+        padded_masked_img[np.where(labs > 1)] = np.nan
 
         plt.imshow(padded_masked_img, origin='lower')
         plt.colorbar()
@@ -450,7 +450,7 @@ if RUN_CODE:
         plt.close()
 
         # noisy_masked_img = noisy_img.copy()
-        # noisy_masked_img[noisy_masked_img < 5 * noise_rms] = np.NaN
+        # noisy_masked_img[noisy_masked_img < 5 * noise_rms] = np.nan
 
         # pspec_noisy_masked = PowerSpectrum(fits.PrimaryHDU(noisy_masked_img))
         # pspec_noisy_masked.run(verbose=True, high_cut=10**-1.2 / u.pix)

--- a/docs/tutorials/missing_data_noise.rst
+++ b/docs/tutorials/missing_data_noise.rst
@@ -90,7 +90,7 @@ Indeed, we recover the correct slope from the delta-variance.
 To demonstrate how masking affects each of these statistics, we will arbitrarily mask low values below the 25 percentile in the example image and run each statistic::
 
     >>> masked_img = img.copy()
-    >>> masked_img[masked_img < np.percentile(img, 25)] = np.NaN
+    >>> masked_img[masked_img < np.percentile(img, 25)] = np.nan
     >>> plt.imshow(masked_img, origin='lower')  # doctest: +SKIP
     >>> plt.colorbar()  # doctest: +SKIP
 
@@ -165,14 +165,14 @@ Another issue that could be encountered with observational data are large empty 
     ...    vector[:pad_width[0]] = pad_value
     ...    vector[-pad_width[1]:] = pad_value
     ...    return vector
-    >>> padded_masked_img = np.pad(masked_img, 128, pad_with, padder=np.NaN)
+    >>> padded_masked_img = np.pad(masked_img, 128, pad_with, padder=np.nan)
 
 We are also only going to keep the biggest continuous region in the padded image to mimic studying a single object picked from a larger image::
 
     >>> from scipy import ndimage as nd
     >>> labs, num = nd.label(np.isfinite(padded_masked_img), np.ones((3, 3)))
     >>> # Keep the largest region only
-    >>> padded_masked_img[np.where(labs > 1)] = np.NaN
+    >>> padded_masked_img[np.where(labs > 1)] = np.nan
     >>> plt.imshow(padded_masked_img, origin='lower')  # doctest: +SKIP
     >>> plt.colorbar()  # doctest: +SKIP
 

--- a/turbustat/moments/_moment_errs.py
+++ b/turbustat/moments/_moment_errs.py
@@ -444,7 +444,7 @@ def _cube1(cube, axis, scale, moment0, moment1):
 
     good_pix = np.isfinite(moment0) + np.isfinite(moment1)
 
-    result[~good_pix] = np.NaN
+    result[~good_pix] = np.nan
 
     return result
 
@@ -488,9 +488,9 @@ def _cube2(cube, axis, scale, moment0, moment1, moment2,
     good_pix = np.isfinite(moment0) + np.isfinite(moment1) + \
         np.isfinite(moment2)
 
-    result[~good_pix] = np.NaN
+    result[~good_pix] = np.nan
 
-    # result[result == 0] = np.NaN
+    # result[result == 0] = np.nan
 
     return result
 

--- a/turbustat/statistics/base_pspec2.py
+++ b/turbustat/statistics/base_pspec2.py
@@ -72,7 +72,7 @@ class StatisticBase_PSpec2D(object):
         self._beam_pow = np.abs(beam_fft**2)
 
         # Avoid infs when dividing out by the beam power spectrum
-        self._beam_pow[self._beam_pow == 0.0] = np.NaN
+        self._beam_pow[self._beam_pow == 0.0] = np.nan
 
     def compute_radial_pspec(self, logspacing=False, max_bin=None, **kwargs):
         '''
@@ -215,7 +215,7 @@ class StatisticBase_PSpec2D(object):
                                                         self.low_cut.value,
                                                         self.high_cut.value)]
 
-            clipped_stddev[clipped_stddev == 0.] = np.NaN
+            clipped_stddev[clipped_stddev == 0.] = np.nan
 
             y_err = 0.434 * clipped_stddev / clipped_ps1D
 

--- a/turbustat/statistics/delta_variance/delta_variance.py
+++ b/turbustat/statistics/delta_variance/delta_variance.py
@@ -201,7 +201,7 @@ class DeltaVariance(BaseStatisticMixIn):
 
             img_core = \
                 convolution_wrapper(pad_img, core, boundary=boundary,
-                                    fill_value=0. if nan_treatment=='fill' else np.NaN,
+                                    fill_value=0. if nan_treatment=='fill' else np.nan,
                                     allow_huge=allow_huge,
                                     nan_treatment=nan_treatment,
                                     use_pyfftw=use_pyfftw,
@@ -210,7 +210,7 @@ class DeltaVariance(BaseStatisticMixIn):
             img_annulus = \
                 convolution_wrapper(pad_img, annulus,
                                     boundary=boundary,
-                                    fill_value=0. if nan_treatment=='fill' else np.NaN,
+                                    fill_value=0. if nan_treatment=='fill' else np.nan,
                                     allow_huge=allow_huge,
                                     nan_treatment=nan_treatment,
                                     use_pyfftw=use_pyfftw,
@@ -219,7 +219,7 @@ class DeltaVariance(BaseStatisticMixIn):
             weights_core = \
                 convolution_wrapper(pad_weights, core,
                                     boundary=boundary,
-                                    fill_value=0. if nan_treatment=='fill' else np.NaN,
+                                    fill_value=0. if nan_treatment=='fill' else np.nan,
                                     allow_huge=allow_huge,
                                     nan_treatment=nan_treatment,
                                     use_pyfftw=use_pyfftw,
@@ -228,7 +228,7 @@ class DeltaVariance(BaseStatisticMixIn):
             weights_annulus = \
                 convolution_wrapper(pad_weights, annulus,
                                     boundary=boundary,
-                                    fill_value=0. if nan_treatment=='fill' else np.NaN,
+                                    fill_value=0. if nan_treatment=='fill' else np.nan,
                                     allow_huge=allow_huge,
                                     nan_treatment=nan_treatment,
                                     use_pyfftw=use_pyfftw,
@@ -236,15 +236,15 @@ class DeltaVariance(BaseStatisticMixIn):
                                     pyfftw_kwargs=pyfftw_kwargs)
 
             cutoff_val = min_weight_frac * self.weights.max()
-            weights_core[np.where(weights_core <= cutoff_val)] = np.NaN
-            weights_annulus[np.where(weights_annulus <= cutoff_val)] = np.NaN
+            weights_core[np.where(weights_core <= cutoff_val)] = np.nan
+            weights_annulus[np.where(weights_annulus <= cutoff_val)] = np.nan
 
             conv_arr = (img_core / weights_core) - \
                 (img_annulus / weights_annulus)
             conv_weight = weights_core * weights_annulus
 
             if preserve_nan:
-                conv_arr[np.isnan(pad_img)] = np.NaN
+                conv_arr[np.isnan(pad_img)] = np.nan
 
             if keep_convolve_arrays:
                 self._convolved_arrays.append(conv_arr)
@@ -253,8 +253,8 @@ class DeltaVariance(BaseStatisticMixIn):
             val, err = _delvar(conv_arr, conv_weight, lag)
 
             if (val <= 0) or (err <= 0) or np.isnan(val) or np.isnan(err):
-                self._delta_var[i] = np.NaN
-                self._delta_var_error[i] = np.NaN
+                self._delta_var[i] = np.nan
+                self._delta_var_error[i] = np.nan
             else:
                 self._delta_var[i] = val
                 self._delta_var_error[i] = err
@@ -908,9 +908,9 @@ class DeltaVariance_Distance(object):
                      "range and lags for both datasets are equal. "
                      "Setting curve_distance to NaN.", TurbuStatMetricWarning)
 
-                self._curve_distance = np.NaN
+                self._curve_distance = np.nan
         else:
-            self._curve_distance = np.NaN
+            self._curve_distance = np.nan
 
         # Distance between the fitted slopes (combined t-statistic)
         self._slope_distance = \

--- a/turbustat/statistics/dendrograms/dendro_stats.py
+++ b/turbustat/statistics/dendrograms/dendro_stats.py
@@ -750,13 +750,13 @@ class Dendrogram_Distance(object):
                                  density=True)[0]
             self.histograms1[n, :] = \
                 np.append(hist1, (np.max(self.nbins) -
-                                  bins.size + 1) * [np.NaN])
+                                  bins.size + 1) * [np.nan])
 
             hist2 = np.histogram(stand_data2, bins=bins,
                                  density=True)[0]
             self.histograms2[n, :] = \
                 np.append(hist2, (np.max(self.nbins) -
-                                  bins.size + 1) * [np.NaN])
+                                  bins.size + 1) * [np.nan])
 
             # Normalize
             self.histograms1[n, :] /= np.nansum(self.histograms1[n, :])

--- a/turbustat/statistics/elliptical_powerlaw.py
+++ b/turbustat/statistics/elliptical_powerlaw.py
@@ -179,7 +179,7 @@ def fit_elliptical_powerlaw(values, x, y, p0, fit_method='LevMarq',
             if cov_matrix is None:
                 warn("Covariance matrix calculation failed. Check results "
                      "carefully.")
-                stderrs = np.zeros((4,)) * np.NaN
+                stderrs = np.zeros((4,)) * np.nan
             else:
                 stderrs = np.sqrt(np.abs(np.diag(cov_matrix)))
 

--- a/turbustat/statistics/pca/width_estimate.py
+++ b/turbustat/statistics/pca/width_estimate.py
@@ -321,7 +321,7 @@ def WidthEstimate1D(inList, method='walk-down'):
                     scales[idx] = interpolator(np.exp(-1))
                 except ValueError:
                     warn("Interpolation failed.")
-                    scales[idx] = np.NaN
+                    scales[idx] = np.nan
                 # scale_errors[idx] = ??
         elif method == 'fit':
             g = models.Gaussian1D(amplitude=y[0], mean=[0], stddev=[10],
@@ -341,8 +341,8 @@ def WidthEstimate1D(inList, method='walk-down'):
             # in NaNs.
             if fit_g.fit_info['param_cov'] is None:
                 warn("Fitting failed.")
-                scales[idx] = np.NaN
-                scale_errors[idx] = np.NaN
+                scales[idx] = np.nan
+                scale_errors[idx] = np.nan
                 continue
 
             errors = np.sqrt(np.abs(fit_g.fit_info['param_cov'].diagonal()))
@@ -367,8 +367,8 @@ def WidthEstimate1D(inList, method='walk-down'):
                     warn("Cannot find width where the 1/e level is"
                          " reached. Ensure the eigenspectra are "
                          "normalized!")
-                    scale_errors[idx] = np.NaN
-                    scales[idx] = np.NaN
+                    scale_errors[idx] = np.nan
+                    scales[idx] = np.nan
 
         else:
             raise ValueError("method must be 'walk-down', 'interpolate' or"
@@ -393,7 +393,7 @@ def fit_2D_ellipse(pts, **bootstrap_kwargs):
         xwidth_err = ellip.param_errs[2] / np.sqrt(2)
         ywidth_err = ellip.param_errs[3] / np.sqrt(2)
     except ValueError:
-        ywidth = xwidth = ywidth_err = xwidth_err = np.NaN
+        ywidth = xwidth = ywidth_err = xwidth_err = np.nan
 
     return ywidth, xwidth, ywidth_err, xwidth_err, ellip
 
@@ -417,7 +417,7 @@ def fit_2D_gaussian(xmat, ymat, z):
 
     if cov is None:
         warn("Fitting failed.")
-        cov = np.zeros((4, 4)) * np.NaN
+        cov = np.zeros((4, 4)) * np.nan
 
     return output, cov
 

--- a/turbustat/statistics/pdf/compare_pdf.py
+++ b/turbustat/statistics/pdf/compare_pdf.py
@@ -307,7 +307,7 @@ class PDF(BaseStatisticMixIn):
                 cov_calc_failed = False
             except ValueError:
                 warn("Variance calculation failed.")
-                self._model_stderrs = np.ones_like(self.model_params) * np.NaN
+                self._model_stderrs = np.ones_like(self.model_params) * np.nan
                 cov_calc_failed = True
         elif fit_type == 'mcmc':
             chain = emcee_fit(self._model,

--- a/turbustat/statistics/psds.py
+++ b/turbustat/statistics/psds.py
@@ -182,10 +182,10 @@ def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
         # Mask out bins that have 1 or fewer points
         mask = bin_cts <= 1
 
-        ps1D_stddev[mask] = np.NaN
-        ps1D[mask] = np.NaN
+        ps1D_stddev[mask] = np.nan
+        ps1D[mask] = np.nan
 
-        # ps1D_stddev[ps1D_stddev == 0.] = np.NaN
+        # ps1D_stddev[ps1D_stddev == 0.] = np.nan
 
         if theta_0 is not None:
             return bin_cents, ps1D, ps1D_stddev, azim_mask

--- a/turbustat/statistics/pspec_bispec/bispec.py
+++ b/turbustat/statistics/pspec_bispec/bispec.py
@@ -603,7 +603,7 @@ class Bispectrum_Distance(object):
         else:
             warn("Bicoherence surface must have equal shapes for the surface"
                  " distance metric.")
-            self._surface_distance = np.NaN
+            self._surface_distance = np.nan
 
         self._mean_distance = np.abs(self.bispec1.bicoherence.mean() -
                                      self.bispec2.bicoherence.mean())

--- a/turbustat/statistics/stat_moments/highstatmoments.py
+++ b/turbustat/statistics/stat_moments/highstatmoments.py
@@ -166,10 +166,10 @@ class StatMoments(BaseStatisticMixIn):
                     np.isfinite(wgt_slice).sum() / float(wgt_slice.size)
 
                 if valid_img_frac < min_frac or valid_wgt_frac < min_frac:
-                    self.mean_array[i - pix_rad, j - pix_rad] = np.NaN
-                    self.variance_array[i - pix_rad, j - pix_rad] = np.NaN
-                    self.skewness_array[i - pix_rad, j - pix_rad] = np.NaN
-                    self.kurtosis_array[i - pix_rad, j - pix_rad] = np.NaN
+                    self.mean_array[i - pix_rad, j - pix_rad] = np.nan
+                    self.variance_array[i - pix_rad, j - pix_rad] = np.nan
+                    self.skewness_array[i - pix_rad, j - pix_rad] = np.nan
+                    self.kurtosis_array[i - pix_rad, j - pix_rad] = np.nan
 
                 else:
                     img_slice = img_slice * circle_mask
@@ -762,7 +762,7 @@ def circular_region(radius):
     circle = circle < radius ** 2.
 
     circle = circle.astype(float)
-    circle[np.where(circle == 0.)] = np.NaN
+    circle[np.where(circle == 0.)] = np.nan
 
     return circle
 

--- a/turbustat/statistics/stats_utils.py
+++ b/turbustat/statistics/stats_utils.py
@@ -560,7 +560,7 @@ def fourier_shift(x, shift, axis=0):
     nonan_shift = _shifter(nonan, shift, axis)
     mask_shift = _shifter(mask, shift, axis) > 0.5
 
-    nonan_shift[mask_shift] = np.NaN
+    nonan_shift[mask_shift] = np.nan
 
     return nonan_shift
 
@@ -612,6 +612,6 @@ def padwithzeros(vector, pad_width, iaxis, kwargs):
 
 
 def padwithnans(vector, pad_width, iaxis, kwargs):
-    vector[:pad_width[0]] = np.NaN
-    vector[-pad_width[1]:] = np.NaN
+    vector[:pad_width[0]] = np.nan
+    vector[-pad_width[1]:] = np.nan
     return vector

--- a/turbustat/statistics/vca_vcs/vcs.py
+++ b/turbustat/statistics/vca_vcs/vcs.py
@@ -488,8 +488,8 @@ class VCS_Distance(object):
 
         # A density distance is only found if a break was found
         if self.vcs1.slope.size == 1 or self.vcs2.slope.size == 1:
-            self.small_scale_distance = np.NaN
-            self.break_distance = np.NaN
+            self.small_scale_distance = np.nan
+            self.break_distance = np.nan
         else:
             self.small_scale_distance = \
                 np.abs((self.vcs1.slope[1] - self.vcs2.slope[1]) /

--- a/turbustat/statistics/wavelets/wavelet_transform.py
+++ b/turbustat/statistics/wavelets/wavelet_transform.py
@@ -258,7 +258,7 @@ class Wavelet(BaseStatisticMixIn):
 
         if weighted_fit:
             y_err = 0.434 * self.stddev / self.values
-            y_err[y_err == 0.] = np.NaN
+            y_err[y_err == 0.] = np.nan
 
             weights = y_err**-2
         else:


### PR DESCRIPTION
Removed deprecated `np.NaN` throughout TurbuStat.